### PR TITLE
Add early versions of matchmake extension common methods

### DIFF
--- a/matchmake_extension/auto_matchmake_postpone.go
+++ b/matchmake_extension/auto_matchmake_postpone.go
@@ -1,0 +1,111 @@
+package matchmake_extension
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"math"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	nexproto "github.com/PretendoNetwork/nex-protocols-go"
+)
+
+func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, matchmakeSession *nexproto.MatchmakeSession, message string) {	
+	gid := FindRoomViaMatchmakeSessionHandler(matchmakeSession)
+	if gid == math.MaxUint32 {
+		gid = NewRoomHandler(client.PID(), matchmakeSession)
+	}
+
+	fmt.Println("GATHERING ID: " + strconv.Itoa((int)(gid)))
+
+	AddPlayerToRoomHandler(gid, client.PID(), uint32(1))
+
+	hostpid, matchmakeSession := GetRoomHandler(gid)
+
+	rmcResponseStream := nex.NewStreamOut(server)
+	rmcResponseStream.WriteString("MatchmakeSession")
+	lengthStream := nex.NewStreamOut(server)
+	lengthStream.WriteStructure(matchmakeSession.Gathering)
+	lengthStream.WriteStructure(matchmakeSession)
+	matchmakeSessionLength := uint32(len(lengthStream.Bytes()))
+	rmcResponseStream.WriteUInt32LE(matchmakeSessionLength + 4)
+	rmcResponseStream.WriteUInt32LE(matchmakeSessionLength)
+	rmcResponseStream.WriteStructure(matchmakeSession.Gathering)
+	rmcResponseStream.WriteStructure(matchmakeSession)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCResponse(nexproto.MatchmakeExtensionProtocolID, callID)
+	rmcResponse.SetSuccess(nexproto.MatchmakeExtensionMethodAutoMatchmake_Postpone, rmcResponseBody)
+
+	rmcResponseBytes := rmcResponse.Bytes()
+	
+	var responsePacket nex.PacketInterface
+
+	if server.PrudpVersion() == 0 {
+		responsePacket, _ = nex.NewPacketV0(client, nil)
+		responsePacket.SetVersion(0)
+	} else {
+		responsePacket, _ = nex.NewPacketV1(client, nil)
+		responsePacket.SetVersion(1)
+	}
+	responsePacket.SetSource(0xA1)
+	responsePacket.SetDestination(0xAF)
+	responsePacket.SetType(nex.DataPacket)
+	responsePacket.SetPayload(rmcResponseBytes)
+
+	responsePacket.AddFlag(nex.FlagNeedsAck)
+	responsePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(responsePacket)
+	
+	rmcMessage := nex.RMCRequest{}
+	rmcMessage.SetProtocolID(0xe)
+	rmcMessage.SetCallID(0xffff0000+callID)
+	rmcMessage.SetMethodID(0x1)
+	clientPidString := fmt.Sprintf("%.8x",(client.PID()))
+	clientPidString = clientPidString[6:8] + clientPidString[4:6] + clientPidString[2:4] + clientPidString[0:2]
+	gidString := fmt.Sprintf("%.8x",(gid))
+	gidString = gidString[6:8] + gidString[4:6] + gidString[2:4] + gidString[0:2]
+	data, _ = hex.DecodeString("0017000000"+hostpidString+"B90B0000"+gidString+clientPidString+"01000001000000")
+	rmcMessage.SetParameters(data)
+	rmcMessageBytes := rmcMessage.Bytes()
+	
+	targetClient := server.FindClientFromPID(uint32(hostpid))
+	
+	var messagePacket nex.PacketInterface
+
+	if server.PrudpVersion() == 0 {
+		messagePacket, _ = nex.NewPacketV0(client, nil)
+		messagePacket.SetVersion(0)
+	} else {
+		messagePacket, _ = nex.NewPacketV1(client, nil)
+		messagePacket.SetVersion(1)
+	}
+	messagePacket.SetSource(0xA1)
+	messagePacket.SetDestination(0xAF)
+	messagePacket.SetType(nex.DataPacket)
+	messagePacket.SetPayload(rmcMessageBytes)
+
+	messagePacket.AddFlag(nex.FlagNeedsAck)
+	messagePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(messagePacket)
+	
+	if server.PrudpVersion() == 0 {
+		messagePacket, _ = nex.NewPacketV0(targetClient, nil)
+		messagePacket.SetVersion(0)
+	} else {
+		messagePacket, _ = nex.NewPacketV1(targetClient, nil)
+		messagePacket.SetVersion(1)
+	}
+	messagePacket.SetSource(0xA1)
+	messagePacket.SetDestination(0xAF)
+	messagePacket.SetType(nex.DataPacket)
+	messagePacket.SetPayload(rmcMessageBytes)
+
+	messagePacket.AddFlag(nex.FlagNeedsAck)
+	messagePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(messagePacket)
+}

--- a/matchmake_extension/auto_matchmake_with_param_postpone.go
+++ b/matchmake_extension/auto_matchmake_with_param_postpone.go
@@ -1,0 +1,197 @@
+package matchmake_extension
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"math"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	nexproto "github.com/PretendoNetwork/nex-protocols-go"
+)
+
+var testGid uint32
+
+func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint32, matchmakeSession *nexproto.MatchmakeSession, sourceGid uint32) {
+	missingHandler := false
+	if (FindRoomViaMatchmakeSessionHandler == nil){
+		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing FindRoomViaMatchmakeSessionHandler!")
+		missingHandler = true
+	}
+	if (AddPlayerToRoomHandler == nil){
+		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing AddPlayerToRoomHandler!")
+		missingHandler = true
+	}
+	if (NewRoomHandler == nil){
+		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing NewRoomHandler!")
+		missingHandler = true
+	}
+	if (missingHandler){
+		return
+	}
+	var gid uint32
+
+	//Splatfest code, there's gotta be a better way to handle this.
+	/*fmt.Println(sourceGid)
+	
+	if((int)(matchmakeSession.GameMode) == 12){
+		var team uint32
+		if(matchmakeSession.Attributes[3] == 0){
+			team = 1
+		}else{
+			team = 0
+		}
+		gid = findRoom(matchmakeSession.GameMode, true, team, matchmakeSession.Attributes[2], uint32(1), matchmakeSession.Attributes[5]&0xF)
+	}else{
+		gid = findRoom(matchmakeSession.GameMode, true, matchmakeSession.Attributes[3], matchmakeSession.Attributes[2], uint32(1), matchmakeSession.Attributes[5]&0xF)
+	}
+	if gid == math.MaxUint32 {
+		gid = newRoom(client.PID(), matchmakeSession.GameMode, true, matchmakeSession.Attributes[3], matchmakeSession.Attributes[2], uint32(1), matchmakeSession.Attributes[5]&0xF)
+	}
+
+	if((int)(matchmakeSession.GameMode) == 12){
+		rmcMessage := nex.RMCRequest{}
+		rmcMessage.SetProtocolID(0xe)
+		rmcMessage.SetCallID(0xffff0000+callID)
+		rmcMessage.SetMethodID(0x1)
+	
+		hostpidString := fmt.Sprintf("%.8x",(client.PID()))
+		hostpidString = hostpidString[6:8] + hostpidString[4:6] + hostpidString[2:4] + hostpidString[0:2]
+		gidString := fmt.Sprintf("%.8x",(gid))
+		gidString = gidString[6:8] + gidString[4:6] + gidString[2:4] + gidString[0:2]
+	
+		for _, pid := range getRoomPlayers(sourceGid) {
+			if(pid == 0){
+				continue
+			}
+			targetClient := nexServer.FindClientFromPID(uint32(pid))
+			if targetClient != nil {
+				clientPidString := fmt.Sprintf("%.8x",(pid))
+				clientPidString = clientPidString[6:8] + clientPidString[4:6] + clientPidString[2:4] + clientPidString[0:2]
+	
+				data, _ := hex.DecodeString("0017000000"+hostpidString+"90DC0100"+gidString+clientPidString+"01000001000000")
+				rmcMessage.SetParameters(data)
+				rmcMessageBytes := rmcMessage.Bytes()
+				messagePacket, _ := nex.NewPacketV1(targetClient, nil)
+				messagePacket.SetVersion(1)
+				messagePacket.SetSource(0xA1)
+				messagePacket.SetDestination(0xAF)
+				messagePacket.SetType(nex.DataPacket)
+				messagePacket.SetPayload(rmcMessageBytes)
+	
+				messagePacket.AddFlag(nex.FlagNeedsAck)
+				messagePacket.AddFlag(nex.FlagReliable)
+	
+				nexServer.Send(messagePacket)
+			}else{
+				fmt.Println("not found")
+			}
+		}
+	}*/
+
+	//fmt.Println("GATHERING ID: " + strconv.Itoa((int)(gid)))
+
+	gid = FindRoomViaMatchmakeSessionHandler(matchmakeSession)
+	if gid == math.MaxUint32 {
+		gid = NewRoomHandler(client.PID(), matchmakeSession)
+	}
+
+	fmt.Println("GATHERING ID: " + strconv.Itoa((int)(gid)))
+
+	AddPlayerToRoomHandler(gid, client.PID(), uint32(1))
+
+	hostpid, matchmakeSession := GetRoomHandler(gid)
+
+	rmcResponseStream := nex.NewStreamOut(server)
+	rmcResponseStream.WriteStructure(matchmakeSession.Gathering)
+	rmcResponseStream.WriteStructure(matchmakeSession)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+	fmt.Println(hex.EncodeToString(rmcResponseBody))
+	hostpidString := fmt.Sprintf("%.8x",(hostpid))
+	hostpidString = hostpidString[6:8] + hostpidString[4:6] + hostpidString[2:4] + hostpidString[0:2]
+	clientPidString := fmt.Sprintf("%.8x",(client.PID()))
+	clientPidString = clientPidString[6:8] + clientPidString[4:6] + clientPidString[2:4] + clientPidString[0:2]
+	gidString := fmt.Sprintf("%.8x",(gid))
+	gidString = gidString[6:8] + gidString[4:6] + gidString[2:4] + gidString[0:2]
+	data, _ := hex.DecodeString("0023000000"+gidString+hostpidString+hostpidString+"000008005f00000000000000000a000000000000010000035c01000001000000060000008108020107000000020000000100000010000000000000000101000000d4000000088100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ea801c8b0000000000010100410000000010011c010000006420000000161466a08c8df18b118ed5a67650a47435f081d09804a7c1902b145e18eff47c00000000001c000000020000000400405352000301050040474952000103000000000000008f7e9e961f000000010000000000000000")
+
+	rmcResponse := nex.NewRMCResponse(nexproto.MatchmakeExtensionProtocolID, callID)
+	rmcResponse.SetSuccess(nexproto.MatchmakeExtensionMethodAutoMatchmakeWithParam_Postpone, rmcResponseBody)
+
+	rmcResponseBytes := rmcResponse.Bytes()
+
+	var responsePacket nex.PacketInterface
+
+	if(server.PrudpVersion() == 0){
+		responsePacket, _ = nex.NewPacketV0(client, nil)
+		responsePacket.SetVersion(0)
+	}else{
+		responsePacket, _ = nex.NewPacketV1(client, nil)
+		responsePacket.SetVersion(1)
+	}
+
+	responsePacket.SetSource(0xA1)
+	responsePacket.SetDestination(0xAF)
+	responsePacket.SetType(nex.DataPacket)
+	responsePacket.SetPayload(rmcResponseBytes)
+
+	responsePacket.AddFlag(nex.FlagNeedsAck)
+	responsePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(responsePacket)
+	
+	rmcMessage := nex.RMCRequest{}
+	rmcMessage.SetProtocolID(0xe)
+	rmcMessage.SetCallID(0xffff0000+callID)
+	rmcMessage.SetMethodID(0x1)
+	if(matchmakeSession.GameMode == 12){
+		//gidString := fmt.Sprintf("%.8x",(testGid))
+		//gidString = gidString[6:8] + gidString[4:6] + gidString[2:4] + gidString[0:2]
+		data, _ = hex.DecodeString("0017000000"+hostpidString+"B90B0000"+gidString+clientPidString+"01000004000000")
+	}else{
+		data, _ = hex.DecodeString("0017000000"+hostpidString+"B90B0000"+gidString+clientPidString+"01000001000000")
+		matchmakeSession.GameMode = 2 
+	}
+	fmt.Println(hex.EncodeToString(data))
+	rmcMessage.SetParameters(data)
+	rmcMessageBytes := rmcMessage.Bytes()
+	
+	targetClient := server.FindClientFromPID(uint32(hostpid))
+	
+	var messagePacket nex.PacketInterface
+
+	if server.PrudpVersion() == 0 {
+		messagePacket, _ = nex.NewPacketV0(client, nil)
+		messagePacket.SetVersion(0)
+	} else {
+		messagePacket, _ = nex.NewPacketV1(client, nil)
+		messagePacket.SetVersion(1)
+	}
+	messagePacket.SetSource(0xA1)
+	messagePacket.SetDestination(0xAF)
+	messagePacket.SetType(nex.DataPacket)
+	messagePacket.SetPayload(rmcMessageBytes)
+
+	messagePacket.AddFlag(nex.FlagNeedsAck)
+	messagePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(messagePacket)
+	
+	if server.PrudpVersion() == 0 {
+		messagePacket, _ = nex.NewPacketV0(targetClient, nil)
+		messagePacket.SetVersion(0)
+	} else {
+		messagePacket, _ = nex.NewPacketV1(targetClient, nil)
+		messagePacket.SetVersion(1)
+	}
+	messagePacket.SetSource(0xA1)
+	messagePacket.SetDestination(0xAF)
+	messagePacket.SetType(nex.DataPacket)
+	messagePacket.SetPayload(rmcMessageBytes)
+
+	messagePacket.AddFlag(nex.FlagNeedsAck)
+	messagePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(messagePacket)
+}

--- a/matchmake_extension/auto_matchmake_with_param_postpone.go
+++ b/matchmake_extension/auto_matchmake_with_param_postpone.go
@@ -14,15 +14,15 @@ var testGid uint32
 
 func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint32, matchmakeSession *nexproto.MatchmakeSession, sourceGid uint32) {
 	missingHandler := false
-	if (FindRoomViaMatchmakeSessionHandler == nil){
+	if (commonMatchmakeExtensionProtocol.FindRoomViaMatchmakeSessionHandler == nil){
 		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing FindRoomViaMatchmakeSessionHandler!")
 		missingHandler = true
 	}
-	if (AddPlayerToRoomHandler == nil){
+	if (commonMatchmakeExtensionProtocol.AddPlayerToRoomHandler == nil){
 		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing AddPlayerToRoomHandler!")
 		missingHandler = true
 	}
-	if (NewRoomHandler == nil){
+	if (commonMatchmakeExtensionProtocol.NewRoomHandler == nil){
 		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing NewRoomHandler!")
 		missingHandler = true
 	}
@@ -91,18 +91,18 @@ func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint3
 
 	//fmt.Println("GATHERING ID: " + strconv.Itoa((int)(gid)))
 
-	gid = FindRoomViaMatchmakeSessionHandler(matchmakeSession)
+	gid = commonMatchmakeExtensionProtocol.FindRoomViaMatchmakeSessionHandler(matchmakeSession)
 	if gid == math.MaxUint32 {
-		gid = NewRoomHandler(client.PID(), matchmakeSession)
+		gid = commonMatchmakeExtensionProtocol.NewRoomHandler(client.PID(), matchmakeSession)
 	}
 
 	fmt.Println("GATHERING ID: " + strconv.Itoa((int)(gid)))
 
-	AddPlayerToRoomHandler(gid, client.PID(), uint32(1))
+	commonMatchmakeExtensionProtocol.AddPlayerToRoomHandler(gid, client.PID(), uint32(1))
 
-	hostpid, matchmakeSession := GetRoomHandler(gid)
+	hostpid, matchmakeSession := commonMatchmakeExtensionProtocol.GetRoomHandler(gid)
 
-	rmcResponseStream := nex.NewStreamOut(server)
+	rmcResponseStream := nex.NewStreamOut(commonMatchmakeExtensionProtocol.server)
 	rmcResponseStream.WriteStructure(matchmakeSession.Gathering)
 	rmcResponseStream.WriteStructure(matchmakeSession)
 
@@ -123,7 +123,7 @@ func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint3
 
 	var responsePacket nex.PacketInterface
 
-	if(server.PrudpVersion() == 0){
+	if(commonMatchmakeExtensionProtocol.server.PrudpVersion() == 0){
 		responsePacket, _ = nex.NewPacketV0(client, nil)
 		responsePacket.SetVersion(0)
 	}else{
@@ -139,7 +139,7 @@ func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint3
 	responsePacket.AddFlag(nex.FlagNeedsAck)
 	responsePacket.AddFlag(nex.FlagReliable)
 
-	server.Send(responsePacket)
+	commonMatchmakeExtensionProtocol.server.Send(responsePacket)
 	
 	rmcMessage := nex.RMCRequest{}
 	rmcMessage.SetProtocolID(0xe)
@@ -157,11 +157,11 @@ func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint3
 	rmcMessage.SetParameters(data)
 	rmcMessageBytes := rmcMessage.Bytes()
 	
-	targetClient := server.FindClientFromPID(uint32(hostpid))
+	targetClient := commonMatchmakeExtensionProtocol.server.FindClientFromPID(uint32(hostpid))
 	
 	var messagePacket nex.PacketInterface
 
-	if server.PrudpVersion() == 0 {
+	if commonMatchmakeExtensionProtocol.server.PrudpVersion() == 0 {
 		messagePacket, _ = nex.NewPacketV0(client, nil)
 		messagePacket.SetVersion(0)
 	} else {
@@ -176,9 +176,9 @@ func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint3
 	messagePacket.AddFlag(nex.FlagNeedsAck)
 	messagePacket.AddFlag(nex.FlagReliable)
 
-	server.Send(messagePacket)
+	commonMatchmakeExtensionProtocol.server.Send(messagePacket)
 	
-	if server.PrudpVersion() == 0 {
+	if commonMatchmakeExtensionProtocol.server.PrudpVersion() == 0 {
 		messagePacket, _ = nex.NewPacketV0(targetClient, nil)
 		messagePacket.SetVersion(0)
 	} else {
@@ -193,5 +193,5 @@ func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint3
 	messagePacket.AddFlag(nex.FlagNeedsAck)
 	messagePacket.AddFlag(nex.FlagReliable)
 
-	server.Send(messagePacket)
+	commonMatchmakeExtensionProtocol.server.Send(messagePacket)
 }

--- a/matchmake_extension/create_matchmake_session.go
+++ b/matchmake_extension/create_matchmake_session.go
@@ -11,32 +11,32 @@ import (
 
 func createMatchmakeSession(err error, client *nex.Client, callID uint32, matchmakeSession *nexproto.MatchmakeSession, message string, participationCount uint16) {
 	missingHandler := false
-	if (FindRoomViaMatchmakeSessionHandler == nil){
+	if (commonMatchmakeExtensionProtocol.FindRoomViaMatchmakeSessionHandler == nil){
 		logger.Warning("MatchmakeExtension::CreateMatchmakeSession missing FindRoomViaMatchmakeSessionHandler!")
 		missingHandler = true
 	}
-	if (AddPlayerToRoomHandler == nil){
+	if (commonMatchmakeExtensionProtocol.AddPlayerToRoomHandler == nil){
 		logger.Warning("MatchmakeExtension::CreateMatchmakeSession missing AddPlayerToRoomHandler!")
 		missingHandler = true
 	}
-	if (NewRoomHandler == nil){
+	if (commonMatchmakeExtensionProtocol.NewRoomHandler == nil){
 		logger.Warning("MatchmakeExtension::CreateMatchmakeSession missing NewRoomHandler!")
 		missingHandler = true
 	}
 	if (missingHandler){
 		return
 	}
-	gid := NewRoomHandler(client.PID(), matchmakeSession)
+	gid := commonMatchmakeExtensionProtocol.NewRoomHandler(client.PID(), matchmakeSession)
 	fmt.Println("===== MATCHMAKE SESSION CREATE =====")
 	fmt.Println("GATHERING ID: " + strconv.Itoa((int)(gid)))
 
-	AddPlayerToRoomHandler(gid, client.PID(), uint32(1))
+	commonMatchmakeExtensionProtocol.AddPlayerToRoomHandler(gid, client.PID(), uint32(1))
 
 	matchmakeSession = nexproto.NewMatchmakeSession()
 
-	_, matchmakeSession = GetRoomHandler(gid)
+	_, matchmakeSession = commonMatchmakeExtensionProtocol.GetRoomHandler(gid)
 
-	rmcResponseStream := nex.NewStreamOut(server)
+	rmcResponseStream := nex.NewStreamOut(commonMatchmakeExtensionProtocol.server)
 	rmcResponseStream.WriteUInt32LE(matchmakeSession.Gathering.ID)
 	rmcResponseStream.WriteBuffer(matchmakeSession.SessionKey)
 
@@ -50,7 +50,7 @@ func createMatchmakeSession(err error, client *nex.Client, callID uint32, matchm
 
 	var responsePacket nex.PacketInterface
 
-	if(server.PrudpVersion() == 0){
+	if(commonMatchmakeExtensionProtocol.server.PrudpVersion() == 0){
 		responsePacket, _ = nex.NewPacketV0(client, nil)
 		responsePacket.SetVersion(0)
 	}else{
@@ -65,7 +65,7 @@ func createMatchmakeSession(err error, client *nex.Client, callID uint32, matchm
 	responsePacket.AddFlag(nex.FlagNeedsAck)
 	responsePacket.AddFlag(nex.FlagReliable)
 
-	server.Send(responsePacket)
+	commonMatchmakeExtensionProtocol.server.Send(responsePacket)
 	
 	rmcMessage := nex.RMCRequest{}
 	rmcMessage.SetProtocolID(0xe)
@@ -82,7 +82,7 @@ func createMatchmakeSession(err error, client *nex.Client, callID uint32, matchm
 	
 	var messagePacket nex.PacketInterface
 
-	if server.PrudpVersion() == 0 {
+	if commonMatchmakeExtensionProtocol.server.PrudpVersion() == 0 {
 		messagePacket, _ = nex.NewPacketV0(client, nil)
 		messagePacket.SetVersion(0)
 	} else {
@@ -97,5 +97,5 @@ func createMatchmakeSession(err error, client *nex.Client, callID uint32, matchm
 	messagePacket.AddFlag(nex.FlagNeedsAck)
 	messagePacket.AddFlag(nex.FlagReliable)
 
-	server.Send(messagePacket)
+	commonMatchmakeExtensionProtocol.server.Send(messagePacket)
 }

--- a/matchmake_extension/create_matchmake_session.go
+++ b/matchmake_extension/create_matchmake_session.go
@@ -1,0 +1,101 @@
+package matchmake_extension
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	nexproto "github.com/PretendoNetwork/nex-protocols-go"
+)
+
+func createMatchmakeSession(err error, client *nex.Client, callID uint32, matchmakeSession *nexproto.MatchmakeSession, message string, participationCount uint16) {
+	missingHandler := false
+	if (FindRoomViaMatchmakeSessionHandler == nil){
+		logger.Warning("MatchmakeExtension::CreateMatchmakeSession missing FindRoomViaMatchmakeSessionHandler!")
+		missingHandler = true
+	}
+	if (AddPlayerToRoomHandler == nil){
+		logger.Warning("MatchmakeExtension::CreateMatchmakeSession missing AddPlayerToRoomHandler!")
+		missingHandler = true
+	}
+	if (NewRoomHandler == nil){
+		logger.Warning("MatchmakeExtension::CreateMatchmakeSession missing NewRoomHandler!")
+		missingHandler = true
+	}
+	if (missingHandler){
+		return
+	}
+	gid := NewRoomHandler(client.PID(), matchmakeSession)
+	fmt.Println("===== MATCHMAKE SESSION CREATE =====")
+	fmt.Println("GATHERING ID: " + strconv.Itoa((int)(gid)))
+
+	AddPlayerToRoomHandler(gid, client.PID(), uint32(1))
+
+	matchmakeSession = nexproto.NewMatchmakeSession()
+
+	_, matchmakeSession = GetRoomHandler(gid)
+
+	rmcResponseStream := nex.NewStreamOut(server)
+	rmcResponseStream.WriteUInt32LE(matchmakeSession.Gathering.ID)
+	rmcResponseStream.WriteBuffer(matchmakeSession.SessionKey)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+	fmt.Println(hex.EncodeToString(rmcResponseBody))
+
+	rmcResponse := nex.NewRMCResponse(nexproto.MatchmakeExtensionProtocolID, callID)
+	rmcResponse.SetSuccess(nexproto.MatchmakeExtensionMethodCreateMatchmakeSessionWithParam, rmcResponseBody)
+
+	rmcResponseBytes := rmcResponse.Bytes()
+
+	var responsePacket nex.PacketInterface
+
+	if(server.PrudpVersion() == 0){
+		responsePacket, _ = nex.NewPacketV0(client, nil)
+		responsePacket.SetVersion(0)
+	}else{
+		responsePacket, _ = nex.NewPacketV1(client, nil)
+		responsePacket.SetVersion(1)
+	}
+	responsePacket.SetSource(0xA1)
+	responsePacket.SetDestination(0xAF)
+	responsePacket.SetType(nex.DataPacket)
+	responsePacket.SetPayload(rmcResponseBytes)
+
+	responsePacket.AddFlag(nex.FlagNeedsAck)
+	responsePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(responsePacket)
+	
+	rmcMessage := nex.RMCRequest{}
+	rmcMessage.SetProtocolID(0xe)
+	rmcMessage.SetCallID(0xffff0000+callID)
+	rmcMessage.SetMethodID(0x1)
+	clientPidString := fmt.Sprintf("%.8x",(client.PID()))
+	clientPidString = clientPidString[6:8] + clientPidString[4:6] + clientPidString[2:4] + clientPidString[0:2]
+	gidString := fmt.Sprintf("%.8x",(gid))
+	gidString = gidString[6:8] + gidString[4:6] + gidString[2:4] + gidString[0:2]
+	data, _ := hex.DecodeString("0017000000"+clientPidString+"B90B0000"+gidString+clientPidString+"01000001000000")
+	fmt.Println(hex.EncodeToString(data))
+	rmcMessage.SetParameters(data)
+	rmcMessageBytes := rmcMessage.Bytes()
+	
+	var messagePacket nex.PacketInterface
+
+	if server.PrudpVersion() == 0 {
+		messagePacket, _ = nex.NewPacketV0(client, nil)
+		messagePacket.SetVersion(0)
+	} else {
+		messagePacket, _ = nex.NewPacketV1(client, nil)
+		messagePacket.SetVersion(1)
+	}
+	messagePacket.SetSource(0xA1)
+	messagePacket.SetDestination(0xAF)
+	messagePacket.SetType(nex.DataPacket)
+	messagePacket.SetPayload(rmcMessageBytes)
+
+	messagePacket.AddFlag(nex.FlagNeedsAck)
+	messagePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(messagePacket)
+}

--- a/matchmake_extension/create_matchmake_session_with_param.go
+++ b/matchmake_extension/create_matchmake_session_with_param.go
@@ -11,32 +11,32 @@ import (
 
 func createMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32, matchmakeSession *nexproto.MatchmakeSession) {
 	missingHandler := false
-	if (FindRoomViaMatchmakeSessionHandler == nil){
+	if (commonMatchmakeExtensionProtocol.FindRoomViaMatchmakeSessionHandler == nil){
 		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing FindRoomViaMatchmakeSessionHandler!")
 		missingHandler = true
 	}
-	if (AddPlayerToRoomHandler == nil){
+	if (commonMatchmakeExtensionProtocol.AddPlayerToRoomHandler == nil){
 		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing AddPlayerToRoomHandler!")
 		missingHandler = true
 	}
-	if (NewRoomHandler == nil){
+	if (commonMatchmakeExtensionProtocol.NewRoomHandler == nil){
 		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing NewRoomHandler!")
 		missingHandler = true
 	}
 	if (missingHandler){
 		return
 	}
-	gid := NewRoomHandler(client.PID(), matchmakeSession)
+	gid := commonMatchmakeExtensionProtocol.NewRoomHandler(client.PID(), matchmakeSession)
 
-	AddPlayerToRoomHandler(gid, client.PID(), uint32(1))
+	commonMatchmakeExtensionProtocol.AddPlayerToRoomHandler(gid, client.PID(), uint32(1))
 
 	matchmakeSession = nexproto.NewMatchmakeSession()
 
-	_, matchmakeSession = GetRoomHandler(gid)
+	_, matchmakeSession = commonMatchmakeExtensionProtocol.GetRoomHandler(gid)
 
 	//sessionKey := "00000000000000000000000000000000"
 
-	rmcResponseStream := nex.NewStreamOut(server)
+	rmcResponseStream := nex.NewStreamOut(commonMatchmakeExtensionProtocol.server)
 	rmcResponseStream.WriteStructure(matchmakeSession.Gathering)
 	rmcResponseStream.WriteStructure(matchmakeSession)
 
@@ -50,7 +50,7 @@ func createMatchmakeSessionWithParam(err error, client *nex.Client, callID uint3
 
 	var responsePacket nex.PacketInterface
 
-	if(server.PrudpVersion() == 0){
+	if(commonMatchmakeExtensionProtocol.server.PrudpVersion() == 0){
 		responsePacket, _ = nex.NewPacketV0(client, nil)
 		responsePacket.SetVersion(0)
 	}else{
@@ -65,7 +65,7 @@ func createMatchmakeSessionWithParam(err error, client *nex.Client, callID uint3
 	responsePacket.AddFlag(nex.FlagNeedsAck)
 	responsePacket.AddFlag(nex.FlagReliable)
 
-	server.Send(responsePacket)
+	commonMatchmakeExtensionProtocol.server.Send(responsePacket)
 	
 	rmcMessage := nex.RMCRequest{}
 	rmcMessage.SetProtocolID(0xe)
@@ -82,7 +82,7 @@ func createMatchmakeSessionWithParam(err error, client *nex.Client, callID uint3
 	
 	var messagePacket nex.PacketInterface
 
-	if server.PrudpVersion() == 0 {
+	if commonMatchmakeExtensionProtocol.server.PrudpVersion() == 0 {
 		messagePacket, _ = nex.NewPacketV0(client, nil)
 		messagePacket.SetVersion(0)
 	} else {
@@ -97,5 +97,5 @@ func createMatchmakeSessionWithParam(err error, client *nex.Client, callID uint3
 	messagePacket.AddFlag(nex.FlagNeedsAck)
 	messagePacket.AddFlag(nex.FlagReliable)
 
-	server.Send(messagePacket)
+	commonMatchmakeExtensionProtocol.server.Send(messagePacket)
 }

--- a/matchmake_extension/create_matchmake_session_with_param.go
+++ b/matchmake_extension/create_matchmake_session_with_param.go
@@ -1,0 +1,101 @@
+package matchmake_extension
+
+import (
+	"encoding/hex"
+	"fmt"
+	//"strconv"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	nexproto "github.com/PretendoNetwork/nex-protocols-go"
+)
+
+func createMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32, matchmakeSession *nexproto.MatchmakeSession) {
+	missingHandler := false
+	if (FindRoomViaMatchmakeSessionHandler == nil){
+		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing FindRoomViaMatchmakeSessionHandler!")
+		missingHandler = true
+	}
+	if (AddPlayerToRoomHandler == nil){
+		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing AddPlayerToRoomHandler!")
+		missingHandler = true
+	}
+	if (NewRoomHandler == nil){
+		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing NewRoomHandler!")
+		missingHandler = true
+	}
+	if (missingHandler){
+		return
+	}
+	gid := NewRoomHandler(client.PID(), matchmakeSession)
+
+	AddPlayerToRoomHandler(gid, client.PID(), uint32(1))
+
+	matchmakeSession = nexproto.NewMatchmakeSession()
+
+	_, matchmakeSession = GetRoomHandler(gid)
+
+	//sessionKey := "00000000000000000000000000000000"
+
+	rmcResponseStream := nex.NewStreamOut(server)
+	rmcResponseStream.WriteStructure(matchmakeSession.Gathering)
+	rmcResponseStream.WriteStructure(matchmakeSession)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+	fmt.Println(hex.EncodeToString(rmcResponseBody))
+
+	rmcResponse := nex.NewRMCResponse(nexproto.MatchmakeExtensionProtocolID, callID)
+	rmcResponse.SetSuccess(nexproto.MatchmakeExtensionMethodCreateMatchmakeSessionWithParam, rmcResponseBody)
+
+	rmcResponseBytes := rmcResponse.Bytes()
+
+	var responsePacket nex.PacketInterface
+
+	if(server.PrudpVersion() == 0){
+		responsePacket, _ = nex.NewPacketV0(client, nil)
+		responsePacket.SetVersion(0)
+	}else{
+		responsePacket, _ = nex.NewPacketV1(client, nil)
+		responsePacket.SetVersion(1)
+	}
+	responsePacket.SetSource(0xA1)
+	responsePacket.SetDestination(0xAF)
+	responsePacket.SetType(nex.DataPacket)
+	responsePacket.SetPayload(rmcResponseBytes)
+
+	responsePacket.AddFlag(nex.FlagNeedsAck)
+	responsePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(responsePacket)
+	
+	rmcMessage := nex.RMCRequest{}
+	rmcMessage.SetProtocolID(0xe)
+	rmcMessage.SetCallID(0xffff0000+callID)
+	rmcMessage.SetMethodID(0x1)
+	clientPidString := fmt.Sprintf("%.8x",(client.PID()))
+	clientPidString = clientPidString[6:8] + clientPidString[4:6] + clientPidString[2:4] + clientPidString[0:2]
+	gidString := fmt.Sprintf("%.8x",(gid))
+	gidString = gidString[6:8] + gidString[4:6] + gidString[2:4] + gidString[0:2]
+	data, _ := hex.DecodeString("0017000000"+clientPidString+"B90B0000"+gidString+clientPidString+"01000001000000")
+	fmt.Println(hex.EncodeToString(data))
+	rmcMessage.SetParameters(data)
+	rmcMessageBytes := rmcMessage.Bytes()
+	
+	var messagePacket nex.PacketInterface
+
+	if server.PrudpVersion() == 0 {
+		messagePacket, _ = nex.NewPacketV0(client, nil)
+		messagePacket.SetVersion(0)
+	} else {
+		messagePacket, _ = nex.NewPacketV1(client, nil)
+		messagePacket.SetVersion(1)
+	}
+	messagePacket.SetSource(0xA1)
+	messagePacket.SetDestination(0xAF)
+	messagePacket.SetType(nex.DataPacket)
+	messagePacket.SetPayload(rmcMessageBytes)
+
+	messagePacket.AddFlag(nex.FlagNeedsAck)
+	messagePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(messagePacket)
+}

--- a/matchmake_extension/join_matchmake_session_with_param.go
+++ b/matchmake_extension/join_matchmake_session_with_param.go
@@ -1,0 +1,147 @@
+package matchmake_extension
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	nexproto "github.com/PretendoNetwork/nex-protocols-go"
+)
+
+func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32, gid uint32) {
+	missingHandler := false
+	if (FindRoomViaMatchmakeSessionHandler == nil){
+		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing FindRoomViaMatchmakeSessionHandler!")
+		missingHandler = true
+	}
+	if (AddPlayerToRoomHandler == nil){
+		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing AddPlayerToRoomHandler!")
+		missingHandler = true
+	}
+	if (GetRoomHandler == nil){
+		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing GetRoomHandler!")
+		missingHandler = true
+	}
+	if (missingHandler){
+		return
+	}
+	fmt.Println("===== MATCHMAKE SESSION JOIN =====")
+	fmt.Println("GATHERING ID: " + strconv.Itoa((int)(gid)))
+
+	AddPlayerToRoomHandler(gid, client.PID(), uint32(1))
+
+	hostpid, matchmakeSession := GetRoomHandler(gid)
+	if(hostpid == 0xffffffff){
+		rmcResponse := nex.NewRMCResponse(nexproto.MatchmakeExtensionProtocolID, callID)
+		rmcResponse.SetError(0x8003006D)
+
+		rmcResponseBytes := rmcResponse.Bytes()
+
+		responsePacket, _ := nex.NewPacketV1(client, nil)
+
+		responsePacket.SetVersion(1)
+		responsePacket.SetSource(0xA1)
+		responsePacket.SetDestination(0xAF)
+		responsePacket.SetType(nex.DataPacket)
+		responsePacket.SetPayload(rmcResponseBytes)
+
+		responsePacket.AddFlag(nex.FlagNeedsAck)
+		responsePacket.AddFlag(nex.FlagReliable)
+
+		server.Send(responsePacket)
+	}
+	
+	//sessionKey := "00000000000000000000000000000000"
+
+	rmcResponseStream := nex.NewStreamOut(server)
+	rmcResponseStream.WriteStructure(matchmakeSession.Gathering)
+	rmcResponseStream.WriteStructure(matchmakeSession)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+	fmt.Println(hex.EncodeToString(rmcResponseBody))
+
+	rmcResponse := nex.NewRMCResponse(nexproto.MatchmakeExtensionProtocolID, callID)
+	rmcResponse.SetSuccess(nexproto.MatchmakeExtensionMethodJoinMatchmakeSessionWithParam, rmcResponseBody)
+
+	rmcResponseBytes := rmcResponse.Bytes()
+
+	var responsePacket nex.PacketInterface
+
+	if(server.PrudpVersion() == 0){
+		responsePacket, _ = nex.NewPacketV0(client, nil)
+		responsePacket.SetVersion(0)
+	}else{
+		responsePacket, _ = nex.NewPacketV1(client, nil)
+		responsePacket.SetVersion(1)
+	}
+	responsePacket.SetSource(0xA1)
+	responsePacket.SetDestination(0xAF)
+	responsePacket.SetType(nex.DataPacket)
+	responsePacket.SetPayload(rmcResponseBytes)
+
+	responsePacket.AddFlag(nex.FlagNeedsAck)
+	responsePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(responsePacket)
+	
+	rmcMessage := nex.RMCRequest{}
+	rmcMessage.SetProtocolID(0xe)
+	rmcMessage.SetCallID(0xffff0000+callID)
+	rmcMessage.SetMethodID(0x1)
+	clientPidString := fmt.Sprintf("%.8x",(client.PID()))
+	clientPidString = clientPidString[6:8] + clientPidString[4:6] + clientPidString[2:4] + clientPidString[0:2]
+	hostPidString := fmt.Sprintf("%.8x",(hostpid))
+	hostPidString = hostPidString[6:8] + hostPidString[4:6] + hostPidString[2:4] + hostPidString[0:2]
+	gidString := fmt.Sprintf("%.8x",(gid))
+	gidString = gidString[6:8] + gidString[4:6] + gidString[2:4] + gidString[0:2]
+	data, _ := hex.DecodeString("0017000000"+clientPidString+"B90B0000"+gidString+clientPidString+"01000001000000")
+	fmt.Println(hex.EncodeToString(data))
+	rmcMessage.SetParameters(data)
+	rmcMessageBytes := rmcMessage.Bytes()
+	
+	targetClient := server.FindClientFromPID(uint32(hostpid))
+	
+	var messagePacket nex.PacketInterface
+
+	if server.PrudpVersion() == 0 {
+		messagePacket, _ = nex.NewPacketV0(client, nil)
+		messagePacket.SetVersion(0)
+	} else {
+		messagePacket, _ = nex.NewPacketV1(client, nil)
+		messagePacket.SetVersion(1)
+	}
+	messagePacket.SetSource(0xA1)
+	messagePacket.SetDestination(0xAF)
+	messagePacket.SetType(nex.DataPacket)
+	messagePacket.SetPayload(rmcMessageBytes)
+
+	messagePacket.AddFlag(nex.FlagNeedsAck)
+	messagePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(messagePacket)
+
+	//data, _ = hex.DecodeString("0017000000"+clientPidString+"B90B0000"+gidString+clientPidString+"01000001000000")
+	fmt.Println(hex.EncodeToString(data))
+	rmcMessage.SetParameters(data)
+	rmcMessageBytes = rmcMessage.Bytes()
+
+	if(targetClient != nil){
+		if server.PrudpVersion() == 0 {
+			messagePacket, _ = nex.NewPacketV0(targetClient, nil)
+			messagePacket.SetVersion(0)
+		} else {
+			messagePacket, _ = nex.NewPacketV1(targetClient, nil)
+			messagePacket.SetVersion(1)
+		}
+		messagePacket.SetSource(0xA1)
+		messagePacket.SetDestination(0xAF)
+		messagePacket.SetType(nex.DataPacket)
+		messagePacket.SetPayload(rmcMessageBytes)
+
+		messagePacket.AddFlag(nex.FlagNeedsAck)
+		messagePacket.AddFlag(nex.FlagReliable)
+
+		server.Send(messagePacket)
+	}
+}

--- a/matchmake_extension/join_matchmake_session_with_param.go
+++ b/matchmake_extension/join_matchmake_session_with_param.go
@@ -11,15 +11,15 @@ import (
 
 func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32, gid uint32) {
 	missingHandler := false
-	if (FindRoomViaMatchmakeSessionHandler == nil){
+	if (commonMatchmakeExtensionProtocol.FindRoomViaMatchmakeSessionHandler == nil){
 		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing FindRoomViaMatchmakeSessionHandler!")
 		missingHandler = true
 	}
-	if (AddPlayerToRoomHandler == nil){
+	if (commonMatchmakeExtensionProtocol.AddPlayerToRoomHandler == nil){
 		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing AddPlayerToRoomHandler!")
 		missingHandler = true
 	}
-	if (GetRoomHandler == nil){
+	if (commonMatchmakeExtensionProtocol.GetRoomHandler == nil){
 		logger.Warning("MatchmakeExtension::AutoMatchmakeWithParam_Postpone missing GetRoomHandler!")
 		missingHandler = true
 	}
@@ -29,9 +29,9 @@ func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32,
 	fmt.Println("===== MATCHMAKE SESSION JOIN =====")
 	fmt.Println("GATHERING ID: " + strconv.Itoa((int)(gid)))
 
-	AddPlayerToRoomHandler(gid, client.PID(), uint32(1))
+	commonMatchmakeExtensionProtocol.AddPlayerToRoomHandler(gid, client.PID(), uint32(1))
 
-	hostpid, matchmakeSession := GetRoomHandler(gid)
+	hostpid, matchmakeSession := commonMatchmakeExtensionProtocol.GetRoomHandler(gid)
 	if(hostpid == 0xffffffff){
 		rmcResponse := nex.NewRMCResponse(nexproto.MatchmakeExtensionProtocolID, callID)
 		rmcResponse.SetError(0x8003006D)
@@ -49,12 +49,12 @@ func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32,
 		responsePacket.AddFlag(nex.FlagNeedsAck)
 		responsePacket.AddFlag(nex.FlagReliable)
 
-		server.Send(responsePacket)
+		commonMatchmakeExtensionProtocol.server.Send(responsePacket)
 	}
 	
 	//sessionKey := "00000000000000000000000000000000"
 
-	rmcResponseStream := nex.NewStreamOut(server)
+	rmcResponseStream := nex.NewStreamOut(commonMatchmakeExtensionProtocol.server)
 	rmcResponseStream.WriteStructure(matchmakeSession.Gathering)
 	rmcResponseStream.WriteStructure(matchmakeSession)
 
@@ -68,7 +68,7 @@ func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32,
 
 	var responsePacket nex.PacketInterface
 
-	if(server.PrudpVersion() == 0){
+	if(commonMatchmakeExtensionProtocol.server.PrudpVersion() == 0){
 		responsePacket, _ = nex.NewPacketV0(client, nil)
 		responsePacket.SetVersion(0)
 	}else{
@@ -83,7 +83,7 @@ func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32,
 	responsePacket.AddFlag(nex.FlagNeedsAck)
 	responsePacket.AddFlag(nex.FlagReliable)
 
-	server.Send(responsePacket)
+	commonMatchmakeExtensionProtocol.server.Send(responsePacket)
 	
 	rmcMessage := nex.RMCRequest{}
 	rmcMessage.SetProtocolID(0xe)
@@ -100,11 +100,11 @@ func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32,
 	rmcMessage.SetParameters(data)
 	rmcMessageBytes := rmcMessage.Bytes()
 	
-	targetClient := server.FindClientFromPID(uint32(hostpid))
+	targetClient := commonMatchmakeExtensionProtocol.server.FindClientFromPID(uint32(hostpid))
 	
 	var messagePacket nex.PacketInterface
 
-	if server.PrudpVersion() == 0 {
+	if commonMatchmakeExtensionProtocol.server.PrudpVersion() == 0 {
 		messagePacket, _ = nex.NewPacketV0(client, nil)
 		messagePacket.SetVersion(0)
 	} else {
@@ -119,7 +119,7 @@ func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32,
 	messagePacket.AddFlag(nex.FlagNeedsAck)
 	messagePacket.AddFlag(nex.FlagReliable)
 
-	server.Send(messagePacket)
+	commonMatchmakeExtensionProtocol.server.Send(messagePacket)
 
 	//data, _ = hex.DecodeString("0017000000"+clientPidString+"B90B0000"+gidString+clientPidString+"01000001000000")
 	fmt.Println(hex.EncodeToString(data))
@@ -127,7 +127,7 @@ func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32,
 	rmcMessageBytes = rmcMessage.Bytes()
 
 	if(targetClient != nil){
-		if server.PrudpVersion() == 0 {
+		if commonMatchmakeExtensionProtocol.server.PrudpVersion() == 0 {
 			messagePacket, _ = nex.NewPacketV0(targetClient, nil)
 			messagePacket.SetVersion(0)
 		} else {
@@ -142,6 +142,6 @@ func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32,
 		messagePacket.AddFlag(nex.FlagNeedsAck)
 		messagePacket.AddFlag(nex.FlagReliable)
 
-		server.Send(messagePacket)
+		commonMatchmakeExtensionProtocol.server.Send(messagePacket)
 	}
 }

--- a/matchmake_extension/protocol.go
+++ b/matchmake_extension/protocol.go
@@ -1,0 +1,56 @@
+package matchmake_extension
+
+import (
+	nex "github.com/PretendoNetwork/nex-go"
+	nexproto "github.com/PretendoNetwork/nex-protocols-go"
+	"github.com/PretendoNetwork/plogger-go"
+)
+
+var (
+	server                                *nex.Server
+	DestroyRoomHandler                    func(gid uint32)
+	GetRoomHandler                        func(gid uint32) (uint32, *nexproto.MatchmakeSession)
+	NewRoomHandler                        func(gid uint32, matchmakeSession *nexproto.MatchmakeSession) (uint32)
+	FindRoomViaMatchmakeSessionHandler    func(matchmakeSession *nexproto.MatchmakeSession) (uint32)
+	AddPlayerToRoomHandler                func(gid uint32, pid uint32, addplayercount uint32)
+)
+
+var logger = plogger.NewLogger()
+
+// DestroyRoom sets the DestroyRoom handler function
+func DestroyRoom(handler func(gid uint32)) {
+	DestroyRoomHandler = handler
+}
+
+// GetRoom sets the GetRoom handler function
+func GetRoom(handler func(gid uint32) (uint32, *nexproto.MatchmakeSession)) {
+	GetRoomHandler = handler
+}
+
+// NewRoom sets the NewRoom handler function
+func NewRoom(handler func(gid uint32, matchmakeSession *nexproto.MatchmakeSession) (uint32)) {
+	NewRoomHandler = handler
+}
+
+// GetRoomInfo sets the GetRoomInfo handler function
+func FindRoomViaMatchmakeSession(handler func(matchmakeSession *nexproto.MatchmakeSession) (uint32)) {
+	FindRoomViaMatchmakeSessionHandler = handler
+}
+
+// AddPlayerToRoom sets the AddPlayerToRoomHandler handler function
+func AddPlayerToRoom(handler func(gid uint32, pid uint32, addplayercount uint32)) {
+	AddPlayerToRoomHandler = handler
+}
+
+// InitMatchmakeExtensionProtocol returns a new MatchmakeExtensionProtocol
+func InitMatchmakeExtensionProtocol(nexServer *nex.Server) *nexproto.MatchmakeExtensionProtocol {
+	server = nexServer
+	matchMakingProtocolServer := nexproto.NewMatchmakeExtensionProtocol(nexServer)
+	matchMakingProtocolServer.AutoMatchmake_Postpone(autoMatchmake_Postpone)
+	matchMakingProtocolServer.AutoMatchmakeWithParam_Postpone(autoMatchmakeWithParam_Postpone)
+	matchMakingProtocolServer.CreateMatchmakeSessionWithParam(createMatchmakeSessionWithParam)
+	matchMakingProtocolServer.CreateMatchmakeSession(createMatchmakeSession)
+	matchMakingProtocolServer.JoinMatchmakeSessionWithParam(joinMatchmakeSessionWithParam)
+
+	return matchMakingProtocolServer
+}

--- a/matchmake_extension/protocol.go
+++ b/matchmake_extension/protocol.go
@@ -6,51 +6,56 @@ import (
 	"github.com/PretendoNetwork/plogger-go"
 )
 
-var (
-	server                                *nex.Server
+var commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol
+
+type CommonMatchmakeExtensionProtocol struct {
+	*nexproto.MatchmakeExtensionProtocol
+	server *nex.Server
+
 	DestroyRoomHandler                    func(gid uint32)
 	GetRoomHandler                        func(gid uint32) (uint32, *nexproto.MatchmakeSession)
 	NewRoomHandler                        func(gid uint32, matchmakeSession *nexproto.MatchmakeSession) (uint32)
 	FindRoomViaMatchmakeSessionHandler    func(matchmakeSession *nexproto.MatchmakeSession) (uint32)
 	AddPlayerToRoomHandler                func(gid uint32, pid uint32, addplayercount uint32)
-)
+}
 
 var logger = plogger.NewLogger()
 
 // DestroyRoom sets the DestroyRoom handler function
-func DestroyRoom(handler func(gid uint32)) {
-	DestroyRoomHandler = handler
+func (commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol) DestroyRoom(handler func(gid uint32)) {
+	commonMatchmakeExtensionProtocol.DestroyRoomHandler = handler
 }
 
 // GetRoom sets the GetRoom handler function
-func GetRoom(handler func(gid uint32) (uint32, *nexproto.MatchmakeSession)) {
-	GetRoomHandler = handler
+func (commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol) GetRoom(handler func(gid uint32) (uint32, *nexproto.MatchmakeSession)) {
+	commonMatchmakeExtensionProtocol.GetRoomHandler = handler
 }
 
 // NewRoom sets the NewRoom handler function
-func NewRoom(handler func(gid uint32, matchmakeSession *nexproto.MatchmakeSession) (uint32)) {
-	NewRoomHandler = handler
+func (commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol) NewRoom(handler func(gid uint32, matchmakeSession *nexproto.MatchmakeSession) (uint32)) {
+	commonMatchmakeExtensionProtocol.NewRoomHandler = handler
 }
 
 // GetRoomInfo sets the GetRoomInfo handler function
-func FindRoomViaMatchmakeSession(handler func(matchmakeSession *nexproto.MatchmakeSession) (uint32)) {
-	FindRoomViaMatchmakeSessionHandler = handler
+func (commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol) FindRoomViaMatchmakeSession(handler func(matchmakeSession *nexproto.MatchmakeSession) (uint32)) {
+	commonMatchmakeExtensionProtocol.FindRoomViaMatchmakeSessionHandler = handler
 }
 
 // AddPlayerToRoom sets the AddPlayerToRoomHandler handler function
-func AddPlayerToRoom(handler func(gid uint32, pid uint32, addplayercount uint32)) {
-	AddPlayerToRoomHandler = handler
+func (commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol) AddPlayerToRoom(handler func(gid uint32, pid uint32, addplayercount uint32)) {
+	commonMatchmakeExtensionProtocol.AddPlayerToRoomHandler = handler
 }
 
-// InitMatchmakeExtensionProtocol returns a new MatchmakeExtensionProtocol
-func InitMatchmakeExtensionProtocol(nexServer *nex.Server) *nexproto.MatchmakeExtensionProtocol {
-	server = nexServer
-	matchMakingProtocolServer := nexproto.NewMatchmakeExtensionProtocol(nexServer)
-	matchMakingProtocolServer.AutoMatchmake_Postpone(autoMatchmake_Postpone)
-	matchMakingProtocolServer.AutoMatchmakeWithParam_Postpone(autoMatchmakeWithParam_Postpone)
-	matchMakingProtocolServer.CreateMatchmakeSessionWithParam(createMatchmakeSessionWithParam)
-	matchMakingProtocolServer.CreateMatchmakeSession(createMatchmakeSession)
-	matchMakingProtocolServer.JoinMatchmakeSessionWithParam(joinMatchmakeSessionWithParam)
+// NewCommonSecureConnectionProtocol returns a new CommonSecureConnectionProtocol
+func NewCommonMatchmakeExtensionProtocol(server *nex.Server) *CommonMatchmakeExtensionProtocol {
+	matchmakeExtensionProtocol := nexproto.NewMatchmakeExtensionProtocol(server)
+	commonMatchmakeExtensionProtocol = &CommonMatchmakeExtensionProtocol{MatchmakeExtensionProtocol: matchmakeExtensionProtocol, server: server}
+	
+	commonMatchmakeExtensionProtocol.AutoMatchmake_Postpone(autoMatchmake_Postpone)
+	commonMatchmakeExtensionProtocol.AutoMatchmakeWithParam_Postpone(autoMatchmakeWithParam_Postpone)
+	commonMatchmakeExtensionProtocol.CreateMatchmakeSessionWithParam(createMatchmakeSessionWithParam)
+	commonMatchmakeExtensionProtocol.CreateMatchmakeSession(createMatchmakeSession)
+	commonMatchmakeExtensionProtocol.JoinMatchmakeSessionWithParam(joinMatchmakeSessionWithParam)
 
-	return matchMakingProtocolServer
+	return commonMatchmakeExtensionProtocol
 }


### PR DESCRIPTION
Still needs a lot to be done, not ready to be merged.
As for how it works:
You're expected to keep 2 copies of the MatchmakeSession in the database: (we'll call them "working copy" and "search copy")
Working copy represents the MatchmakeSession as it is given to the console in the response, and is what should be modified.
Search copy represents the MatchmakeSession as it is used when searching for a match. This should only be modified to remove undesired search criteria (such as Splatfest power in Splatoon, or precise VR/BR in MK7), and modifications must be performed the *same way* when both searching for a match (to the search MatchmakeSession) and when making a match (to the saved search copy).
