### PR TITLE
Various fixes

### DIFF
--- a/authentication/login.go
+++ b/authentication/login.go
@@ -42,6 +42,8 @@ func login(err error, client *nex.Client, callID uint32, username string) {
 		pConnectionData.SetStationURL(commonAuthenticationProtocol.secureStationURL.EncodeToString())
 		pConnectionData.SetSpecialProtocols([]byte{})
 		pConnectionData.SetStationURLSpecialProtocols("")
+		serverTime := nex.NewDateTime(0)
+		pConnectionData.SetTime(serverTime.UTC())
 
 		/*
 			From the wiki:

--- a/authentication/login_ex.go
+++ b/authentication/login_ex.go
@@ -42,6 +42,8 @@ func loginEx(err error, client *nex.Client, callID uint32, username string, auth
 		pConnectionData.SetStationURL(commonAuthenticationProtocol.secureStationURL.EncodeToString())
 		pConnectionData.SetSpecialProtocols([]byte{})
 		pConnectionData.SetStationURLSpecialProtocols("")
+		serverTime := nex.NewDateTime(0)
+		pConnectionData.SetTime(serverTime.UTC())
 
 		/*
 			From the wiki:

--- a/secure-connection/register.go
+++ b/secure-connection/register.go
@@ -29,7 +29,7 @@ func register(err error, client *nex.Client, callID uint32, stationUrls []*nex.S
 	localStationURL := localStation.EncodeToString()
 	pidConnectionID := uint32(server.ConnectionIDCounter().Increment())
 	client.SetConnectionID(pidConnectionID)
-	client.SetLocalStationUrl(localStationURL)
+	client.SetLocalStationURL(localStationURL)
 
 	address := client.Address().IP.String()
 	port := strconv.Itoa(client.Address().Port)


### PR DESCRIPTION
Rename `SetLocalStationUrl` to `SetLocalStationURL`, as this function was renamed when linting nex-go.

Besides, add current UTC time to RVConnectionData on login methods to fix Badge Arcade time.