### PR TITLE
Lots of changes on common protocols

### DIFF
--- a/authentication/login_ex.go
+++ b/authentication/login_ex.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PretendoNetwork/nex-protocols-go/authentication"
 )
 
-func loginEx(err error, client *nex.Client, callID uint32, username string, authenticationInfo *authentication.AuthenticationInfo) {
+func loginEx(err error, client *nex.Client, callID uint32, username string, oExtraData *nex.DataHolder) {
 	var userPID uint32
 
 	if username == "guest" {

--- a/authentication/protocol.go
+++ b/authentication/protocol.go
@@ -2,6 +2,7 @@ package authentication
 
 import (
 	"github.com/PretendoNetwork/nex-go"
+	_ "github.com/PretendoNetwork/nex-protocols-go"
 	"github.com/PretendoNetwork/nex-protocols-go/authentication"
 	"github.com/PretendoNetwork/plogger-go"
 )

--- a/globals/matchmaking_globals.go
+++ b/globals/matchmaking_globals.go
@@ -5,8 +5,8 @@ import (
 )
 
 type CommonMatchmakeSession struct {
-	GameMatchmakeSession match_making.MatchmakeSession //used by the game, contains the current state of the MatchmakeSession
-	SearchMatchmakeSession match_making.MatchmakeSession //used by the server when searching for matches, contains the state of the MatchmakeSession during the search process for easy compares
+	GameMatchmakeSession *match_making.MatchmakeSession //used by the game, contains the current state of the MatchmakeSession
+	SearchMatchmakeSession *match_making.MatchmakeSession //used by the server when searching for matches, contains the state of the MatchmakeSession during the search process for easy compares
 	ConnectionIDs []uint32 //players in the room, referenced by their connection IDs. This is used instead of the PID in order to ensure we're talking to the correct client (in case of e.g. multiple logins)
 }
 
@@ -14,7 +14,20 @@ var Sessions map[uint32]*CommonMatchmakeSession
 var CurrentGatheringID uint32
 
 func DeleteIndex(s []uint32, index int) []uint32 {
-    return append(s[:index], s[index+1:]...)
+	if len(s) <= 1 {
+		return make([]uint32, 0)
+	}
+
+	return append(s[:index], s[index+1:]...)
+}
+
+func FindOtherConnectionID(myConnectionID uint32, gathering uint32) uint32 {
+	for _, connectionID := range Sessions[gathering].ConnectionIDs {
+		if connectionID != myConnectionID {
+			return connectionID
+		}
+	}
+	return math.MaxUint32
 }
 
 func RemoveConnectionIDFromRoom(clientConnectionID uint32, gathering uint32) {
@@ -41,17 +54,17 @@ func FindClientSession(clientConnectionID uint32) uint32 {
 
 func RemoveConnectionIDFromAllSessions(clientConnectionID uint32) {
 	foundSession := FindClientSession(clientConnectionID)
-	if(foundSession != math.MaxUint32){
+	if foundSession != math.MaxUint32 {
 		RemoveConnectionIDFromRoom(clientConnectionID, foundSession)
 	}
 }
 
-func FindSearchMatchmakeSession(searchMatchmakeSession match_making.MatchmakeSession) int {
+func FindSearchMatchmakeSession(searchMatchmakeSession *match_making.MatchmakeSession) int {
 	returnSessionIndex := math.MaxUint32
 	//this portion finds any sessions that match the search session. It does not care about anything beyond that, such as if the match is already full. This is handled below.
 	candidateSessionIndexes := make([]uint32, 0, len(Sessions))
 	for index, session := range Sessions {
-		if session.SearchMatchmakeSession.Equals(&searchMatchmakeSession) {
+		if session.SearchMatchmakeSession.Equals(searchMatchmakeSession) {
 			candidateSessionIndexes = append(candidateSessionIndexes, index)
 		}
 	}

--- a/globals/matchmaking_globals.go
+++ b/globals/matchmaking_globals.go
@@ -2,7 +2,6 @@ package common_globals
 import (
 	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
 	"math"
-	"reflect"
 )
 
 type CommonMatchmakeSession struct {
@@ -25,7 +24,7 @@ func RemoveConnectionIDFromRoom(clientConnectionID uint32, gathering uint32) {
 		}
 	}
 	if len(Sessions[gathering].ConnectionIDs) == 0 {
-        delete(Sessions, gathering)
+		delete(Sessions, gathering)
 	}
 }
 
@@ -52,7 +51,7 @@ func FindSearchMatchmakeSession(searchMatchmakeSession match_making.MatchmakeSes
 	//this portion finds any sessions that match the search session. It does not care about anything beyond that, such as if the match is already full. This is handled below.
 	candidateSessionIndexes := make([]uint32, 0, len(Sessions))
 	for index, session := range Sessions {
-		if reflect.DeepEqual(session.SearchMatchmakeSession, searchMatchmakeSession) { // TODO - for Jon: Equals in StructureInterface
+		if session.SearchMatchmakeSession.Equals(&searchMatchmakeSession) {
 			candidateSessionIndexes = append(candidateSessionIndexes, index)
 		}
 	}

--- a/globals/matchmaking_globals.go
+++ b/globals/matchmaking_globals.go
@@ -1,35 +1,50 @@
 package common_globals
 import (
-	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
 	"math"
+
+	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
 )
 
 type CommonMatchmakeSession struct {
-	GameMatchmakeSession *match_making.MatchmakeSession //used by the game, contains the current state of the MatchmakeSession
-	SearchMatchmakeSession *match_making.MatchmakeSession //used by the server when searching for matches, contains the state of the MatchmakeSession during the search process for easy compares
-	ConnectionIDs []uint32 //players in the room, referenced by their connection IDs. This is used instead of the PID in order to ensure we're talking to the correct client (in case of e.g. multiple logins)
+	GameMatchmakeSession *match_making.MatchmakeSession // Used by the game, contains the current state of the MatchmakeSession
+	SearchMatchmakeSession *match_making.MatchmakeSession // Used by the server when searching for matches, contains the state of the MatchmakeSession during the search process for easy compares
+	ConnectionIDs []uint32 // Players in the room, referenced by their connection IDs. This is used instead of the PID in order to ensure we're talking to the correct client (in case of e.g. multiple logins)
 }
 
 var Sessions map[uint32]*CommonMatchmakeSession
-var CurrentGatheringID uint32
 
-func DeleteIndex(s []uint32, index int) []uint32 {
-	if len(s) <= 1 {
-		return make([]uint32, 0)
+// GetSessionIndex returns a gathering ID which doesn't belong to any session
+func GetSessionIndex() uint32 {
+	var gatheringID uint32 = 1
+	for gatheringID < math.MaxUint32 {
+		// If the session does not exist, the gathering ID is empty and can be used
+		if _, ok := Sessions[gatheringID]; !ok {
+			return gatheringID
+		}
+
+		gatheringID++
 	}
 
-	return append(s[:index], s[index+1:]...)
+	return 0
 }
 
+// DeleteIndex removes a value from a slice with the given index
+func DeleteIndex(s []uint32, index int) []uint32 {
+	s[index] = s[len(s)-1]
+	return s[:len(s)-1]
+}
+
+// FindOtherConnectionID searches a connection ID on the gathering that isn't the given one
 func FindOtherConnectionID(myConnectionID uint32, gathering uint32) uint32 {
 	for _, connectionID := range Sessions[gathering].ConnectionIDs {
 		if connectionID != myConnectionID {
 			return connectionID
 		}
 	}
-	return math.MaxUint32
+	return 0
 }
 
+// RemoveConnectionIDFromRoom removes a client from the gathering
 func RemoveConnectionIDFromRoom(clientConnectionID uint32, gathering uint32) {
 	for index, connectionID := range Sessions[gathering].ConnectionIDs {
 		if connectionID == clientConnectionID {
@@ -41,6 +56,7 @@ func RemoveConnectionIDFromRoom(clientConnectionID uint32, gathering uint32) {
 	}
 }
 
+// FindClientSession searches the gathering where the client is on
 func FindClientSession(clientConnectionID uint32) uint32 {
 	for gatheringID := range Sessions {
 		for _, connectionID := range Sessions[gatheringID].ConnectionIDs {
@@ -49,19 +65,22 @@ func FindClientSession(clientConnectionID uint32) uint32 {
 			}
 		}
 	}
-	return math.MaxUint32
+	return 0
 }
 
+// RemoveConnectionIDFromAllSessions removes a client from every session
 func RemoveConnectionIDFromAllSessions(clientConnectionID uint32) {
 	foundSession := FindClientSession(clientConnectionID)
-	if foundSession != math.MaxUint32 {
-		RemoveConnectionIDFromRoom(clientConnectionID, foundSession)
+	if foundSession != 0 {
+		RemoveConnectionIDFromRoom(clientConnectionID, uint32(foundSession))
 	}
 }
 
-func FindSearchMatchmakeSession(searchMatchmakeSession *match_making.MatchmakeSession) int {
-	returnSessionIndex := math.MaxUint32
-	//this portion finds any sessions that match the search session. It does not care about anything beyond that, such as if the match is already full. This is handled below.
+// SearchGatheringWithMatchmakeSession finds a gathering that matches with a MatchmakeSession
+func SearchGatheringWithMatchmakeSession(searchMatchmakeSession *match_making.MatchmakeSession) uint32 {
+	var returnSessionIndex uint32 = 0
+
+	// This portion finds any sessions that match the search session. It does not care about anything beyond that, such as if the match is already full. This is handled below.
 	candidateSessionIndexes := make([]uint32, 0, len(Sessions))
 	for index, session := range Sessions {
 		if session.SearchMatchmakeSession.Equals(searchMatchmakeSession) {
@@ -73,7 +92,7 @@ func FindSearchMatchmakeSession(searchMatchmakeSession *match_making.MatchmakeSe
 		if len(sessionToCheck.ConnectionIDs) >= int(sessionToCheck.GameMatchmakeSession.MaximumParticipants) {
 			continue
 		} else {
-			returnSessionIndex = int(sessionIndex) //found a match
+			returnSessionIndex = sessionIndex //found a match
 			break
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/PretendoNetwork/nex-protocols-common-go
 go 1.19
 
 require (
-	github.com/PretendoNetwork/nex-go v1.0.25
-	github.com/PretendoNetwork/nex-protocols-go v1.0.28
+	github.com/PretendoNetwork/nex-go v1.0.26
+	github.com/PretendoNetwork/nex-protocols-go v1.0.32
 	github.com/PretendoNetwork/plogger-go v1.0.2
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/PretendoNetwork/nex-protocols-common-go
 go 1.19
 
 require (
-	github.com/PretendoNetwork/nex-go v1.0.22
-	github.com/PretendoNetwork/nex-protocols-go v1.0.26
+	github.com/PretendoNetwork/nex-go v1.0.25
+	github.com/PretendoNetwork/nex-protocols-go v1.0.28
 	github.com/PretendoNetwork/plogger-go v1.0.2
 )
 
@@ -12,7 +12,7 @@ require (
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/jwalton/go-supportscolor v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/superwhiskers/crunch/v3 v3.5.7 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/PretendoNetwork/nex-go v1.0.25 h1:x324hqKItxZSq+8KFhdwjVusB9y05CciTmAOZ+i819U=
-github.com/PretendoNetwork/nex-go v1.0.25/go.mod h1:qzc5s4iNrt1ubS9Axb38b2jPuEsiETN2mDijn+MthmI=
-github.com/PretendoNetwork/nex-protocols-go v1.0.28 h1:Nn+qt0pqwALvnlYwfTk34uEt4w3LRRkTurLelsKWcyo=
-github.com/PretendoNetwork/nex-protocols-go v1.0.28/go.mod h1:YXXNqT7mjE/fDX4ia/liLzrzJxzdSRIlwQ+2MA2LRls=
+github.com/PretendoNetwork/nex-go v1.0.26 h1:lJqDS5F8s836xcQzCEI5hNvUesmTsh2NGDC4tZvG250=
+github.com/PretendoNetwork/nex-go v1.0.26/go.mod h1:qzc5s4iNrt1ubS9Axb38b2jPuEsiETN2mDijn+MthmI=
+github.com/PretendoNetwork/nex-protocols-go v1.0.32 h1:FdZwpzDdhNLSX1DVQIK91b8a+QI7Z6ow7hYlbMEjBYI=
+github.com/PretendoNetwork/nex-protocols-go v1.0.32/go.mod h1:Pw1u2rsZGXuv45iM9y/7nZ5TBr1L5hctv9ylNXlW1ws=
 github.com/PretendoNetwork/plogger-go v1.0.2 h1:vWKEnEmJJzYwqLxLyiSsAvCrZV6qnnu/a0GQOjIfzY0=
 github.com/PretendoNetwork/plogger-go v1.0.2/go.mod h1:7kD6M4vPq1JL4LTuPg6kuB1OvUBOwQOtAvTaUwMbwvU=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/PretendoNetwork/nex-go v1.0.22 h1:BXUvnp++muen86t2Iv47h2ZCX8xWMw00p8nTzS57zRE=
-github.com/PretendoNetwork/nex-go v1.0.22/go.mod h1:Bx2ONeSefnbJyE0IDIwGopxrjRrnszOV/uQv74Cx+m0=
-github.com/PretendoNetwork/nex-protocols-go v1.0.26 h1:jscXlgcyz1xZVY4kyR2m9366uof8pm9msf+IOtK6tVU=
-github.com/PretendoNetwork/nex-protocols-go v1.0.26/go.mod h1:Rg3dwo0dU+uujoI9q1kcQkDiSYKpuew0xF8ojIaUPm0=
+github.com/PretendoNetwork/nex-go v1.0.25 h1:x324hqKItxZSq+8KFhdwjVusB9y05CciTmAOZ+i819U=
+github.com/PretendoNetwork/nex-go v1.0.25/go.mod h1:qzc5s4iNrt1ubS9Axb38b2jPuEsiETN2mDijn+MthmI=
+github.com/PretendoNetwork/nex-protocols-go v1.0.28 h1:Nn+qt0pqwALvnlYwfTk34uEt4w3LRRkTurLelsKWcyo=
+github.com/PretendoNetwork/nex-protocols-go v1.0.28/go.mod h1:YXXNqT7mjE/fDX4ia/liLzrzJxzdSRIlwQ+2MA2LRls=
 github.com/PretendoNetwork/plogger-go v1.0.2 h1:vWKEnEmJJzYwqLxLyiSsAvCrZV6qnnu/a0GQOjIfzY0=
 github.com/PretendoNetwork/plogger-go v1.0.2/go.mod h1:7kD6M4vPq1JL4LTuPg6kuB1OvUBOwQOtAvTaUwMbwvU=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
@@ -12,8 +12,8 @@ github.com/jwalton/go-supportscolor v1.1.0/go.mod h1:hFVUAZV2cWg+WFFC4v8pT2X/S2q
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
-github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
+github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/superwhiskers/crunch/v3 v3.5.7 h1:N9RLxaR65C36i26BUIpzPXGy2f6pQ7wisu2bawbKNqg=
 github.com/superwhiskers/crunch/v3 v3.5.7/go.mod h1:4ub2EKgF1MAhTjoOCTU4b9uLMsAweHEa89aRrfAypXA=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/matchmake-extension/auto_matchmake_postpone.go
+++ b/matchmake-extension/auto_matchmake_postpone.go
@@ -8,7 +8,7 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, matchmakeSession *match_making.MatchmakeSession, message string) {
+func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, anyGathering *nex.DataHolder, message string) {
 	server := commonMatchmakeExtensionProtocol.server
 	if commonMatchmakeExtensionProtocol.cleanupSearchMatchmakeSessionHandler == nil {
 		logger.Warning("MatchmakeExtension::AutoMatchmake_Postpone missing CleanupSearchMatchmakeSessionHandler!")
@@ -18,6 +18,13 @@ func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, matchm
 	// A client may disconnect from a session without leaving reliably,
 	// so let's make sure the client is removed from the session
 	common_globals.RemoveConnectionIDFromAllSessions(client.ConnectionID())
+
+	var matchmakeSession *match_making.MatchmakeSession
+	anyGatheringDataType := anyGathering.TypeName()
+
+	if anyGatheringDataType == "MatchmakeSession" {
+		matchmakeSession = anyGathering.ObjectData().(*match_making.MatchmakeSession)
+	}
 
 	searchMatchmakeSession := matchmakeSession.Copy().(*match_making.MatchmakeSession)
 	commonMatchmakeExtensionProtocol.cleanupSearchMatchmakeSessionHandler(searchMatchmakeSession)

--- a/matchmake-extension/protocol.go
+++ b/matchmake-extension/protocol.go
@@ -14,12 +14,12 @@ type CommonMatchmakeExtensionProtocol struct {
 	*matchmake_extension.MatchmakeExtensionProtocol
 	server *nex.Server
 
-	CleanupSearchMatchmakeSessionHandler    func(matchmakeSession match_making.MatchmakeSession) match_making.MatchmakeSession
+	cleanupSearchMatchmakeSessionHandler    func(matchmakeSession match_making.MatchmakeSession) match_making.MatchmakeSession
 }
 
 // CleanupSearchMatchmakeSession sets the CleanupSearchMatchmakeSession handler function
 func (commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol) CleanupSearchMatchmakeSession(handler func(matchmakeSession match_making.MatchmakeSession) match_making.MatchmakeSession) {
-	commonMatchmakeExtensionProtocol.CleanupSearchMatchmakeSessionHandler = handler
+	commonMatchmakeExtensionProtocol.cleanupSearchMatchmakeSessionHandler = handler
 }
 
 // NewCommonMatchmakeExtensionProtocol returns a new CommonMatchmakeExtensionProtocol

--- a/matchmake-extension/protocol.go
+++ b/matchmake-extension/protocol.go
@@ -14,11 +14,11 @@ type CommonMatchmakeExtensionProtocol struct {
 	*matchmake_extension.MatchmakeExtensionProtocol
 	server *nex.Server
 
-	cleanupSearchMatchmakeSessionHandler    func(matchmakeSession match_making.MatchmakeSession) match_making.MatchmakeSession
+	cleanupSearchMatchmakeSessionHandler    func(matchmakeSession *match_making.MatchmakeSession)
 }
 
 // CleanupSearchMatchmakeSession sets the CleanupSearchMatchmakeSession handler function
-func (commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol) CleanupSearchMatchmakeSession(handler func(matchmakeSession match_making.MatchmakeSession) match_making.MatchmakeSession) {
+func (commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol) CleanupSearchMatchmakeSession(handler func(matchmakeSession *match_making.MatchmakeSession)) {
 	commonMatchmakeExtensionProtocol.cleanupSearchMatchmakeSessionHandler = handler
 }
 
@@ -27,7 +27,7 @@ func NewCommonMatchmakeExtensionProtocol(server *nex.Server) *CommonMatchmakeExt
 	MatchmakeExtensionProtocol := matchmake_extension.NewMatchmakeExtensionProtocol(server)
 	commonMatchmakeExtensionProtocol = &CommonMatchmakeExtensionProtocol{MatchmakeExtensionProtocol: MatchmakeExtensionProtocol, server: server}
 
-	MatchmakeExtensionProtocol.AutoMatchmake_Postpone(AutoMatchmake_Postpone)
+	MatchmakeExtensionProtocol.AutoMatchmake_Postpone(autoMatchmake_Postpone)
 
 	return commonMatchmakeExtensionProtocol
 }

--- a/matchmaking-ext/end_participation.go
+++ b/matchmaking-ext/end_participation.go
@@ -1,8 +1,6 @@
 package match_making_ext
 
 import (
-	"math"
-
 	nex "github.com/PretendoNetwork/nex-go"
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 	match_making_ext "github.com/PretendoNetwork/nex-protocols-go/match-making-ext"
@@ -19,7 +17,7 @@ func endParticipation(err error, client *nex.Client, callID uint32, idGathering 
 		// Flag 0x10 tells the server to change the matchmake session owner if they disconnect
 		// If the flag is not set, delete the session
 		// More info: https://nintendo-wiki.pretendo.network/docs/nex/protocols/match-making/types#flags
-		if matchmakeSession.Gathering.Flags & 0x10 == 0 {
+		if matchmakeSession.Gathering.Flags & 0x10 == 0 { // DisconnectChangeOwner
 			deleteSession = true
 		} else {
 			changeSessionOwner(client.ConnectionID(), idGathering, callID)
@@ -108,8 +106,8 @@ func changeSessionOwner(ownerConnectionID uint32, gathering uint32, callID uint3
 	var otherClient *nex.Client
 
 	otherConnectionID := common_globals.FindOtherConnectionID(ownerConnectionID, gathering)
-	if otherConnectionID != math.MaxUint32 {
-		otherClient = server.FindClientFromConnectionID(otherConnectionID)
+	if otherConnectionID != 0 {
+		otherClient = server.FindClientFromConnectionID(uint32(otherConnectionID))
 		if otherClient != nil {
 			common_globals.Sessions[gathering].GameMatchmakeSession.Gathering.OwnerPID = otherClient.PID()
 		} else {
@@ -131,7 +129,7 @@ func changeSessionOwner(ownerConnectionID uint32, gathering uint32, callID uint3
 	oEvent.Param1 = gathering
 	oEvent.Param2 = otherClient.PID()
 
-	// TODO - This doesn't seem to appear on all servers
+	// TODO - StrParam doesn't have this value on some servers
 	// https://github.com/kinnay/NintendoClients/issues/101
 	// unixTime := time.Now()
 	// oEvent.StrParam = strconv.FormatInt(unixTime.UnixMicro(), 10)

--- a/matchmaking-ext/end_participation.go
+++ b/matchmaking-ext/end_participation.go
@@ -13,18 +13,24 @@ func endParticipation(err error, client *nex.Client, callID uint32, idGathering 
 	server := commonMatchMakingExtProtocol.server
 	matchmakeSession := common_globals.Sessions[idGathering].GameMatchmakeSession
 	ownerPID := matchmakeSession.Gathering.OwnerPID
+
+	var deleteSession bool = false
 	if client.PID() == matchmakeSession.Gathering.OwnerPID {
 		// Flag 0x10 tells the server to change the matchmake session owner if they disconnect
 		// If the flag is not set, delete the session
 		// More info: https://nintendo-wiki.pretendo.network/docs/nex/protocols/match-making/types#flags
 		if matchmakeSession.Gathering.Flags & 0x10 == 0 {
-			delete(common_globals.Sessions, idGathering)
+			deleteSession = true
 		} else {
-			changeSessionOwner(client.ConnectionID(), idGathering)
+			changeSessionOwner(client.ConnectionID(), idGathering, callID)
 		}
 	}
 
-	common_globals.RemoveConnectionIDFromRoom(client.ConnectionID(), idGathering)
+	if deleteSession {
+		delete(common_globals.Sessions, idGathering)
+	} else {
+		common_globals.RemoveConnectionIDFromRoom(client.ConnectionID(), idGathering)
+	}
 
 	rmcResponseStream := nex.NewStreamOut(server)
 
@@ -97,16 +103,69 @@ func endParticipation(err error, client *nex.Client, callID uint32, idGathering 
 	server.Send(messagePacket)
 }
 
-func changeSessionOwner(ownerConnectionID uint32, gathering uint32) {
+func changeSessionOwner(ownerConnectionID uint32, gathering uint32, callID uint32) {
+	server := commonMatchMakingExtProtocol.server
+	var otherClient *nex.Client
+
 	otherConnectionID := common_globals.FindOtherConnectionID(ownerConnectionID, gathering)
 	if otherConnectionID != math.MaxUint32 {
-		server := commonMatchMakingExtProtocol.server
-
-		otherClient := server.FindClientFromConnectionID(otherConnectionID)
+		otherClient = server.FindClientFromConnectionID(otherConnectionID)
 		if otherClient != nil {
 			common_globals.Sessions[gathering].GameMatchmakeSession.Gathering.OwnerPID = otherClient.PID()
 		} else {
 			logger.Warning("Other client not found")
+			return
+		}
+	} else {
+		return
+	}
+
+	rmcMessage := nex.NewRMCRequest()
+	rmcMessage.SetProtocolID(notifications.ProtocolID)
+	rmcMessage.SetCallID(0xffff0000 + callID)
+	rmcMessage.SetMethodID(notifications.MethodProcessNotificationEvent)
+
+	oEvent := notifications.NewNotificationEvent()
+	oEvent.PIDSource = otherClient.PID()
+	oEvent.Type = notifications.NotificationTypes.OwnershipChanged
+	oEvent.Param1 = gathering
+	oEvent.Param2 = otherClient.PID()
+
+	// TODO - This doesn't seem to appear on all servers
+	// https://github.com/kinnay/NintendoClients/issues/101
+	// unixTime := time.Now()
+	// oEvent.StrParam = strconv.FormatInt(unixTime.UnixMicro(), 10)
+
+	stream := nex.NewStreamOut(server)
+	oEventBytes := oEvent.Bytes(stream)
+	rmcMessage.SetParameters(oEventBytes)
+
+	rmcRequestBytes := rmcMessage.Bytes()
+
+	for _, connectionID := range common_globals.Sessions[gathering].ConnectionIDs {
+		targetClient := server.FindClientFromConnectionID(connectionID)
+		if targetClient != nil {
+			var messagePacket nex.PacketInterface
+
+			if server.PRUDPVersion() == 0 {
+				messagePacket, _ = nex.NewPacketV0(targetClient, nil)
+				messagePacket.SetVersion(0)
+			} else {
+				messagePacket, _ = nex.NewPacketV1(targetClient, nil)
+				messagePacket.SetVersion(1)
+			}
+
+			messagePacket.SetSource(0xA1)
+			messagePacket.SetDestination(0xAF)
+			messagePacket.SetType(nex.DataPacket)
+			messagePacket.SetPayload(rmcRequestBytes)
+
+			messagePacket.AddFlag(nex.FlagNeedsAck)
+			messagePacket.AddFlag(nex.FlagReliable)
+
+			server.Send(messagePacket)
+		} else {
+			logger.Warning("Client not found")
 		}
 	}
 }

--- a/matchmaking-ext/end_participation.go
+++ b/matchmaking-ext/end_participation.go
@@ -3,6 +3,7 @@ package match_making_ext
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
+	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
 	match_making_ext "github.com/PretendoNetwork/nex-protocols-go/match-making-ext"
 	"github.com/PretendoNetwork/nex-protocols-go/notifications"
 )
@@ -14,10 +15,10 @@ func endParticipation(err error, client *nex.Client, callID uint32, idGathering 
 
 	var deleteSession bool = false
 	if client.PID() == matchmakeSession.Gathering.OwnerPID {
-		// Flag 0x10 tells the server to change the matchmake session owner if they disconnect
+		// This flag tells the server to change the matchmake session owner if they disconnect
 		// If the flag is not set, delete the session
 		// More info: https://nintendo-wiki.pretendo.network/docs/nex/protocols/match-making/types#flags
-		if matchmakeSession.Gathering.Flags & 0x10 == 0 { // DisconnectChangeOwner
+		if matchmakeSession.Gathering.Flags & match_making.GatheringFlags.DisconnectChangeOwner == 0 {
 			deleteSession = true
 		} else {
 			changeSessionOwner(client.ConnectionID(), idGathering, callID)

--- a/matchmaking-ext/end_participation.go
+++ b/matchmaking-ext/end_participation.go
@@ -4,10 +4,19 @@ import (
 	nex "github.com/PretendoNetwork/nex-go"
 	match_making_ext "github.com/PretendoNetwork/nex-protocols-go/match-making-ext"
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
+	"github.com/PretendoNetwork/nex-protocols-go/notifications"
 )
 
 func EndParticipation(err error, client *nex.Client, callID uint32, idGathering uint32, strMessage string) {
 	server := commonMatchMakingExtProtocol.server
+	matchmakeSession := common_globals.Sessions[idGathering].GameMatchmakeSession
+	ownerPID := matchmakeSession.Gathering.OwnerPID
+	if client.PID() == matchmakeSession.Gathering.OwnerPID {
+		if matchmakeSession.Gathering.Flags & 0x10 == 0 {
+			delete(common_globals.Sessions, idGathering)
+		}
+	}
+
 	common_globals.RemoveConnectionIDFromRoom(client.ConnectionID(), idGathering)
 
 	rmcResponseStream := nex.NewStreamOut(server)
@@ -40,4 +49,43 @@ func EndParticipation(err error, client *nex.Client, callID uint32, idGathering 
 	responsePacket.AddFlag(nex.FlagReliable)
 
 	server.Send(responsePacket)
+
+	rmcMessage := nex.NewRMCRequest()
+	rmcMessage.SetProtocolID(notifications.ProtocolID)
+	rmcMessage.SetCallID(0xffff0000 + callID)
+	rmcMessage.SetMethodID(notifications.MethodProcessNotificationEvent)
+
+	oEvent := notifications.NewNotificationEvent()
+	oEvent.PIDSource = client.PID()
+	oEvent.Type = notifications.NotificationTypes.ParticipationEnded
+	oEvent.Param1 = idGathering
+	oEvent.Param2 = client.PID()
+	oEvent.StrParam = strMessage
+
+	stream := nex.NewStreamOut(server)
+	oEventBytes := oEvent.Bytes(stream)
+	rmcMessage.SetParameters(oEventBytes)
+
+	rmcMessageBytes := rmcMessage.Bytes()
+
+	targetClient := server.FindClientFromPID(uint32(ownerPID))
+
+	var messagePacket nex.PacketInterface
+
+	if server.PRUDPVersion() == 0 {
+		messagePacket, _ = nex.NewPacketV0(targetClient, nil)
+		messagePacket.SetVersion(0)
+	} else {
+		messagePacket, _ = nex.NewPacketV1(targetClient, nil)
+		messagePacket.SetVersion(1)
+	}
+	messagePacket.SetSource(0xA1)
+	messagePacket.SetDestination(0xAF)
+	messagePacket.SetType(nex.DataPacket)
+	messagePacket.SetPayload(rmcMessageBytes)
+
+	messagePacket.AddFlag(nex.FlagNeedsAck)
+	messagePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(messagePacket)
 }

--- a/matchmaking-ext/protocol.go
+++ b/matchmaking-ext/protocol.go
@@ -19,7 +19,7 @@ func NewCommonMatchMakingExtProtocol(server *nex.Server) *CommonMatchMakingExtPr
 	MatchMakingExtProtocol := match_making_ext.NewMatchMakingExtProtocol(server)
 	commonMatchMakingExtProtocol = &CommonMatchMakingExtProtocol{MatchMakingExtProtocol: MatchMakingExtProtocol, server: server}
 
-	MatchMakingExtProtocol.EndParticipation(EndParticipation)
+	MatchMakingExtProtocol.EndParticipation(endParticipation)
 
 	return commonMatchMakingExtProtocol
 }

--- a/matchmaking/get_session_urls.go
+++ b/matchmaking/get_session_urls.go
@@ -4,32 +4,20 @@ import (
 	nex "github.com/PretendoNetwork/nex-go"
 	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
-	"fmt"
 )
 
 func getSessionURLs(err error, client *nex.Client, callID uint32, gatheringId uint32) {
 	server := commonMatchMakingProtocol.server
-	missingHandler := false
-	if commonMatchMakingProtocol.GetConnectionUrlsHandler == nil {
-		logger.Warning("MatchMaking::GetSessionURLs missing GetConnectionUrlsHandler!")
-		missingHandler = true
-	}
-	if commonMatchMakingProtocol.GetRoomInfoHandler == nil {
-		logger.Warning("MatchMaking::GetSessionURLs missing GetRoomInfoHandler!")
-		missingHandler = true
-	}
-	if missingHandler {
-		return
-	}
 	var stationUrlStrings []string
 
 	hostpid := common_globals.Sessions[gatheringId].GameMatchmakeSession.Gathering.HostPID
 
 	hostclient := server.FindClientFromPID(hostpid)
-	if(hostclient == nil){
-		fmt.Println("nil hostclient?!") //this popped up once during testing. Leaving it noted here in case it becomes a problem.
+	if hostclient == nil {
+		logger.Warning("Host client not found") //this popped up once during testing. Leaving it noted here in case it becomes a problem.
 		return
 	}
+
 	stationUrlStrings = hostclient.StationURLs()
 
 	rmcResponseStream := nex.NewStreamOut(server)

--- a/matchmaking/protocol.go
+++ b/matchmaking/protocol.go
@@ -14,37 +14,6 @@ var logger = plogger.NewLogger()
 type CommonMatchMakingProtocol struct {
 	*match_making.MatchMakingProtocol
 	server *nex.Server
-
-	GetConnectionUrlsHandler func(rvcid uint32) []string
-	UpdateRoomHostHandler    func(gid uint32, newownerpid uint32)
-	DestroyRoomHandler       func(gid uint32)
-	GetRoomInfoHandler       func(gid uint32) (uint32, uint32, uint32, uint32, uint32)
-	GetRoomPlayersHandler    func(gid uint32) []uint32
-}
-
-// GetConnectionUrls sets the GetConnectionUrls handler function
-func (commonMatchMakingProtocol *CommonMatchMakingProtocol) GetConnectionUrls(handler func(rvcid uint32) []string) {
-	commonMatchMakingProtocol.GetConnectionUrlsHandler = handler
-}
-
-// UpdateRoomHost sets the UpdateRoomHost handler function
-func (commonMatchMakingProtocol *CommonMatchMakingProtocol) UpdateRoomHost(handler func(gid uint32, newownerpid uint32)) {
-	commonMatchMakingProtocol.UpdateRoomHostHandler = handler
-}
-
-// DestroyRoom sets the DestroyRoom handler function
-func (commonMatchMakingProtocol *CommonMatchMakingProtocol) DestroyRoom(handler func(gid uint32)) {
-	commonMatchMakingProtocol.DestroyRoomHandler = handler
-}
-
-// GetRoomInfo sets the GetRoomInfo handler function
-func (commonMatchMakingProtocol *CommonMatchMakingProtocol) GetRoomInfo(handler func(gid uint32) (uint32, uint32, uint32, uint32, uint32)) {
-	commonMatchMakingProtocol.GetRoomInfoHandler = handler
-}
-
-// GetRoomPlayers sets the GetRoomPlayers handler function
-func (commonMatchMakingProtocol *CommonMatchMakingProtocol) GetRoomPlayers(handler func(gid uint32) []uint32) {
-	commonMatchMakingProtocol.GetRoomPlayersHandler = handler
 }
 
 // NewCommonMatchMakingProtocol returns a new CommonMatchMakingProtocol
@@ -52,7 +21,7 @@ func NewCommonMatchMakingProtocol(server *nex.Server) *CommonMatchMakingProtocol
 	matchMakingProtocol := match_making.NewMatchMakingProtocol(server)
 	commonMatchMakingProtocol = &CommonMatchMakingProtocol{MatchMakingProtocol: matchMakingProtocol, server: server}
 
-    common_globals.Sessions = make(map[uint32]*common_globals.CommonMatchmakeSession)
+	common_globals.Sessions = make(map[uint32]*common_globals.CommonMatchmakeSession)
 
 	commonMatchMakingProtocol.GetSessionURLs(getSessionURLs)
 	commonMatchMakingProtocol.UnregisterGathering(unregisterGathering)

--- a/matchmaking/protocol.go
+++ b/matchmaking/protocol.go
@@ -2,6 +2,7 @@ package matchmaking
 
 import (
 	nex "github.com/PretendoNetwork/nex-go"
+	_ "github.com/PretendoNetwork/nex-protocols-go"
 	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
 	"github.com/PretendoNetwork/plogger-go"
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"

--- a/matchmaking/update_session_host.go
+++ b/matchmaking/update_session_host.go
@@ -54,7 +54,7 @@ func updateSessionHost(err error, client *nex.Client, callID uint32, gid uint32,
 	oEvent.Param1 = gid
 	oEvent.Param2 = client.PID()
 
-	// TODO - This doesn't seem to appear on all servers
+	// TODO - StrParam doesn't have this value on some servers
 	// https://github.com/kinnay/NintendoClients/issues/101
 	// unixTime := time.Now()
 	// oEvent.StrParam = strconv.FormatInt(unixTime.UnixMicro(), 10)

--- a/matchmaking/update_session_host.go
+++ b/matchmaking/update_session_host.go
@@ -1,25 +1,18 @@
 package matchmaking
 
 import (
-	"strconv"
-	"time"
-
 	nex "github.com/PretendoNetwork/nex-go"
 	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
 	"github.com/PretendoNetwork/nex-protocols-go/notifications"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func updateSessionHost(err error, client *nex.Client, callID uint32, gid uint32) {
+func updateSessionHost(err error, client *nex.Client, callID uint32, gid uint32, isMigrateOwner bool) {
 	server := commonMatchMakingProtocol.server
-	missingHandler := false
-	if commonMatchMakingProtocol.UpdateRoomHostHandler == nil {
-		logger.Warning("MatchMaking::UpdateSessionHostV1 missing UpdateRoomHostHandler!")
-		missingHandler = true
+	common_globals.Sessions[gid].GameMatchmakeSession.Gathering.HostPID = client.PID()
+	if isMigrateOwner {
+		common_globals.Sessions[gid].GameMatchmakeSession.Gathering.OwnerPID = client.PID()
 	}
-	if missingHandler {
-		return
-	}
-	commonMatchMakingProtocol.UpdateRoomHostHandler(gid, client.PID())
 
 	rmcResponse := nex.NewRMCResponse(match_making.ProtocolID, callID)
 	rmcResponse.SetSuccess(match_making.MethodUpdateSessionHost, nil)
@@ -46,6 +39,10 @@ func updateSessionHost(err error, client *nex.Client, callID uint32, gid uint32)
 
 	server.Send(responsePacket)
 
+	if !isMigrateOwner {
+		return
+	}
+
 	rmcMessage := nex.NewRMCRequest()
 	rmcMessage.SetProtocolID(notifications.ProtocolID)
 	rmcMessage.SetCallID(0xffff0000 + callID)
@@ -53,13 +50,14 @@ func updateSessionHost(err error, client *nex.Client, callID uint32, gid uint32)
 
 	oEvent := notifications.NewNotificationEvent()
 	oEvent.PIDSource = client.PID()
-	oEvent.Type = 4000 // Ownership changed
+	oEvent.Type = notifications.NotificationTypes.OwnershipChanged
 	oEvent.Param1 = gid
 	oEvent.Param2 = client.PID()
 
+	// TODO - This doesn't seem to appear on all servers
 	// https://github.com/kinnay/NintendoClients/issues/101
-	unixTime := time.Now()
-	oEvent.StrParam = strconv.FormatInt(unixTime.UnixMicro(), 10)
+	// unixTime := time.Now()
+	// oEvent.StrParam = strconv.FormatInt(unixTime.UnixMicro(), 10)
 
 	stream := nex.NewStreamOut(server)
 	oEventBytes := oEvent.Bytes(stream)
@@ -67,14 +65,9 @@ func updateSessionHost(err error, client *nex.Client, callID uint32, gid uint32)
 
 	rmcRequestBytes := rmcMessage.Bytes()
 
-	for _, pid := range commonMatchMakingProtocol.GetRoomPlayersHandler(gid) {
-		if pid == 0 {
-			continue
-		}
-
-		targetClient := server.FindClientFromPID(uint32(pid))
+	for _, connectionID := range common_globals.Sessions[gid].ConnectionIDs {
+		targetClient := server.FindClientFromConnectionID(connectionID)
 		if targetClient != nil {
-
 			var messagePacket nex.PacketInterface
 
 			if server.PRUDPVersion() == 0 {
@@ -98,16 +91,4 @@ func updateSessionHost(err error, client *nex.Client, callID uint32, gid uint32)
 			logger.Warning("Client not found")
 		}
 	}
-
-	messagePacket, _ := nex.NewPacketV0(client, nil)
-	messagePacket.SetVersion(1)
-	messagePacket.SetSource(0xA1)
-	messagePacket.SetDestination(0xAF)
-	messagePacket.SetType(nex.DataPacket)
-	messagePacket.SetPayload(rmcRequestBytes)
-
-	messagePacket.AddFlag(nex.FlagNeedsAck)
-	messagePacket.AddFlag(nex.FlagReliable)
-
-	server.Send(messagePacket)
 }

--- a/matchmaking/update_session_host_v1.go
+++ b/matchmaking/update_session_host_v1.go
@@ -3,19 +3,12 @@ package matchmaking
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func updateSessionHostV1(err error, client *nex.Client, callID uint32, gid uint32) {
 	server := commonMatchMakingProtocol.server
-	missingHandler := false
-	if commonMatchMakingProtocol.UpdateRoomHostHandler == nil {
-		logger.Warning("MatchMaking::UpdateSessionHostV1 missing UpdateRoomHostHandler!")
-		missingHandler = true
-	}
-	if missingHandler {
-		return
-	}
-	commonMatchMakingProtocol.UpdateRoomHostHandler(gid, client.PID())
+	common_globals.Sessions[gid].GameMatchmakeSession.Gathering.HostPID = client.PID()
 
 	rmcResponse := nex.NewRMCResponse(match_making.ProtocolID, callID)
 	rmcResponse.SetSuccess(match_making.MethodUpdateSessionHostV1, nil)

--- a/nat-traversal/protocol.go
+++ b/nat-traversal/protocol.go
@@ -6,31 +6,21 @@ import (
 	"github.com/PretendoNetwork/plogger-go"
 )
 
-var (
-	server                      *nex.Server
-	GetConnectionUrlsHandler    func(rvcid uint32) []string
-	ReplaceConnectionUrlHandler func(rvcid uint32, oldurl string, newurl string)
-)
-
+var commonNATTraversalProtocol *CommonNATTraversalProtocol
 var logger = plogger.NewLogger()
 
-// GetConnectionUrls sets the GetConnectionUrls handler function
-func GetConnectionUrls(handler func(rvcid uint32) []string) {
-	GetConnectionUrlsHandler = handler
+type CommonNATTraversalProtocol struct {
+	*nat_traversal.NATTraversalProtocol
+	server                      *nex.Server
 }
 
-// ReplaceConnectionUrl sets the ReplaceConnectionUrl handler function
-func ReplaceConnectionUrl(handler func(rvcid uint32, oldurl string, newurl string)) {
-	ReplaceConnectionUrlHandler = handler
-}
+// NewCommonNATTraversalProtocol returns a new CommonNATTraversalProtocol
+func NewCommonNATTraversalProtocol(server *nex.Server) *CommonNATTraversalProtocol {
+	natTraversalProtocol := nat_traversal.NewNATTraversalProtocol(server)
+	commonNATTraversalProtocol = &CommonNATTraversalProtocol{NATTraversalProtocol: natTraversalProtocol, server: server}
 
-// InitNatTraversalProtocol returns a new NatTraversalProtocol
-func InitNatTraversalProtocol(nexServer *nex.Server) *nat_traversal.NATTraversalProtocol {
-	server = nexServer
-	natTraversalProtocolServer := nat_traversal.NewNATTraversalProtocol(nexServer)
-
-	natTraversalProtocolServer.RequestProbeInitiationExt(requestProbeInitiationExt)
-	natTraversalProtocolServer.ReportNATProperties(reportNatProperties)
-	//natTraversalProtocolServer.ReportNATTraversalResult(reportNATTraversalResult) // not implemented in nex-protocols-go yet
-	return natTraversalProtocolServer
+	commonNATTraversalProtocol.RequestProbeInitiationExt(requestProbeInitiationExt)
+	commonNATTraversalProtocol.ReportNATProperties(reportNATProperties)
+	commonNATTraversalProtocol.ReportNATTraversalResult(reportNATTraversalResult)
+	return commonNATTraversalProtocol
 }

--- a/nat-traversal/report_nat_traversal_result.go
+++ b/nat-traversal/report_nat_traversal_result.go
@@ -2,35 +2,35 @@ package nattraversal
 
 import (
 	nex "github.com/PretendoNetwork/nex-go"
+	nat_traversal "github.com/PretendoNetwork/nex-protocols-go/nat-traversal"
 )
 
 func reportNATTraversalResult(err error, client *nex.Client, callID uint32, cid uint32, result bool, rtt uint32) {
-	// MethodReportNATTraversalResult does not exist yet in nex-protocols-go
-	/*
-		rmcResponse := nex.NewRMCResponse(nexproto.ProtocolID, callID)
-		rmcResponse.SetSuccess(nexproto.MethodReportNATTraversalResult, nil)
+	server := commonNATTraversalProtocol.server
 
-		rmcResponseBytes := rmcResponse.Bytes()
+	rmcResponse := nex.NewRMCResponse(nat_traversal.ProtocolID, callID)
+	rmcResponse.SetSuccess(nat_traversal.MethodReportNATTraversalResult, nil)
 
-		var responsePacket nex.PacketInterface
+	rmcResponseBytes := rmcResponse.Bytes()
 
-		if server.PRUDPVersion() == 0 {
-			responsePacket, _ = nex.NewPacketV0(client, nil)
-			responsePacket.SetVersion(0)
-		} else {
-			responsePacket, _ = nex.NewPacketV1(client, nil)
-			responsePacket.SetVersion(1)
-		}
+	var responsePacket nex.PacketInterface
 
+	if server.PRUDPVersion() == 0 {
+		responsePacket, _ = nex.NewPacketV0(client, nil)
+		responsePacket.SetVersion(0)
+	} else {
+		responsePacket, _ = nex.NewPacketV1(client, nil)
 		responsePacket.SetVersion(1)
-		responsePacket.SetSource(0xA1)
-		responsePacket.SetDestination(0xAF)
-		responsePacket.SetType(nex.DataPacket)
-		responsePacket.SetPayload(rmcResponseBytes)
+	}
 
-		responsePacket.AddFlag(nex.FlagNeedsAck)
-		responsePacket.AddFlag(nex.FlagReliable)
+	responsePacket.SetVersion(1)
+	responsePacket.SetSource(0xA1)
+	responsePacket.SetDestination(0xAF)
+	responsePacket.SetType(nex.DataPacket)
+	responsePacket.SetPayload(rmcResponseBytes)
 
-		server.Send(responsePacket)
-	*/
+	responsePacket.AddFlag(nex.FlagNeedsAck)
+	responsePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(responsePacket)
 }

--- a/nat-traversal/report_nat_traversal_result.go
+++ b/nat-traversal/report_nat_traversal_result.go
@@ -23,7 +23,6 @@ func reportNATTraversalResult(err error, client *nex.Client, callID uint32, cid 
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetVersion(1)
 	responsePacket.SetSource(0xA1)
 	responsePacket.SetDestination(0xAF)
 	responsePacket.SetType(nex.DataPacket)

--- a/secure-connection/connect.go
+++ b/secure-connection/connect.go
@@ -38,8 +38,8 @@ func connect(packet nex.PacketInterface) {
 	ticketTime := ticket.Timestamp().Standard()
 	serverTime := time.Now().UTC()
 
-	timeLimit := serverTime.Add(time.Minute * 2)
-	if ticketTime.After(timeLimit) {
+	timeLimit := ticketTime.Add(time.Minute * 2)
+	if serverTime.After(timeLimit) {
 		logger.Error("Kerberos ticket expired")
 		server.TimeoutKick(packet.Sender())
 		return

--- a/secure-connection/connect.go
+++ b/secure-connection/connect.go
@@ -1,6 +1,7 @@
 package secureconnection
 
 import (
+	"time"
 	"github.com/PretendoNetwork/nex-go"
 )
 
@@ -10,26 +11,71 @@ func connect(packet nex.PacketInterface) {
 
 	stream := nex.NewStreamIn(payload, server)
 
-	// TODO: Error check!!
-	ticketData, _ := stream.ReadBuffer()
-	requestData, _ := stream.ReadBuffer()
+	ticketData, err := stream.ReadBuffer()
+	if err != nil {
+		logger.Error(err.Error())
+		server.TimeoutKick(packet.Sender())
+		return
+	}
+
+	requestData, err := stream.ReadBuffer()
+	if err != nil {
+		logger.Error(err.Error())
+		server.TimeoutKick(packet.Sender())
+		return
+	}
 
 	serverKey := nex.DeriveKerberosKey(2, []byte(server.KerberosPassword()))
 
 	ticket := nex.NewKerberosTicketInternalData()
-	ticket.Decrypt(nex.NewStreamIn(ticketData, server), serverKey)
+	err = ticket.Decrypt(nex.NewStreamIn(ticketData, server), serverKey)
+	if err != nil {
+		logger.Error(err.Error())
+		server.TimeoutKick(packet.Sender())
+		return
+	}
 
-	// TODO: Check timestamp here
+	ticketTime := ticket.Timestamp().Standard()
+	serverTime := time.Now().UTC()
+
+	timeLimit := serverTime.Add(time.Minute * 2)
+	if ticketTime.After(timeLimit) {
+		logger.Error("Kerberos ticket expired")
+		server.TimeoutKick(packet.Sender())
+		return
+	}
 
 	sessionKey := ticket.SessionKey()
-	kerberos := nex.NewKerberosEncryption(sessionKey)
+	kerberos, err := nex.NewKerberosEncryption(sessionKey)
+	if err != nil {
+		logger.Error(err.Error())
+		server.TimeoutKick(packet.Sender())
+		return
+	}
 
 	decryptedRequestData := kerberos.Decrypt(requestData)
 	checkDataStream := nex.NewStreamIn(decryptedRequestData, server)
 
-	userPID := checkDataStream.ReadUInt32LE()
-	_ = checkDataStream.ReadUInt32LE() //CID of secure server station url
-	responseCheck := checkDataStream.ReadUInt32LE()
+	userPID, err := checkDataStream.ReadUInt32LE()
+	if err != nil {
+		logger.Error(err.Error())
+		server.TimeoutKick(packet.Sender())
+		return
+	}
+
+	_, err = checkDataStream.ReadUInt32LE() // CID of secure server station url
+	if err != nil {
+		logger.Error(err.Error())
+		server.TimeoutKick(packet.Sender())
+		return
+	}
+
+	responseCheck, err := checkDataStream.ReadUInt32LE()
+	if err != nil {
+		logger.Error(err.Error())
+		server.TimeoutKick(packet.Sender())
+		return
+	}
 
 	responseValueStream := nex.NewStreamOut(server)
 	responseValueStream.WriteUInt32LE(responseCheck + 1)

--- a/secure-connection/protocol.go
+++ b/secure-connection/protocol.go
@@ -12,31 +12,6 @@ var logger = plogger.NewLogger()
 type CommonSecureConnectionProtocol struct {
 	*secure_connection.SecureConnectionProtocol
 	server *nex.Server
-
-	addConnectionHandler        func(rvcid uint32, urls []string, ip string, port string)
-	updateConnectionHandler     func(rvcid uint32, urls []string, ip string, port string)
-	doesConnectionExistHandler  func(rvcid uint32) bool
-	replaceConnectionUrlHandler func(rvcid uint32, oldurl string, newurl string)
-}
-
-// AddConnection sets the AddConnection handler function
-func (commonSecureConnectionProtocol *CommonSecureConnectionProtocol) AddConnection(handler func(rvcid uint32, urls []string, ip string, port string)) {
-	commonSecureConnectionProtocol.addConnectionHandler = handler
-}
-
-// UpdateConnection sets the UpdateConnection handler function
-func (commonSecureConnectionProtocol *CommonSecureConnectionProtocol) UpdateConnection(handler func(rvcid uint32, urls []string, ip string, port string)) {
-	commonSecureConnectionProtocol.updateConnectionHandler = handler
-}
-
-// ReplaceConnectionUrl sets the ReplaceConnectionUrl handler function
-func (commonSecureConnectionProtocol *CommonSecureConnectionProtocol) ReplaceConnectionUrl(handler func(rvcid uint32, oldurl string, newurl string)) {
-	commonSecureConnectionProtocol.replaceConnectionUrlHandler = handler
-}
-
-// DoesConnectionExist sets the DoesConnectionExist handler function
-func (commonSecureConnectionProtocol *CommonSecureConnectionProtocol) DoesConnectionExist(handler func(rvcid uint32) bool) {
-	commonSecureConnectionProtocol.doesConnectionExistHandler = handler
 }
 
 // NewCommonSecureConnectionProtocol returns a new CommonSecureConnectionProtocol

--- a/secure-connection/register.go
+++ b/secure-connection/register.go
@@ -9,22 +9,6 @@ import (
 
 func register(err error, client *nex.Client, callID uint32, stationUrls []*nex.StationURL) {
 	server := commonSecureConnectionProtocol.server
-	missingHandler := false
-	if commonSecureConnectionProtocol.addConnectionHandler == nil {
-		logger.Warning("Missing AddConnectionHandler!")
-		missingHandler = true
-	}
-	if commonSecureConnectionProtocol.updateConnectionHandler == nil {
-		logger.Warning("Missing UpdateConnectionHandler!")
-		missingHandler = true
-	}
-	if commonSecureConnectionProtocol.doesConnectionExistHandler == nil {
-		logger.Warning("Missing DoesConnectionExistHandler!")
-		missingHandler = true
-	}
-	if missingHandler {
-		return
-	}
 	localStation := stationUrls[0]
 	localStationURL := localStation.EncodeToString()
 	pidConnectionID := uint32(server.ConnectionIDCounter().Increment())

--- a/secure-connection/replace_url.go
+++ b/secure-connection/replace_url.go
@@ -7,10 +7,6 @@ import (
 
 func replaceURL(err error, client *nex.Client, callID uint32, oldStation *nex.StationURL, newStation *nex.StationURL) {
 	server := commonSecureConnectionProtocol.server
-	if commonSecureConnectionProtocol.replaceConnectionUrlHandler == nil {
-		logger.Warning("Missing ReplaceConnectionUrlHandler!")
-		return
-	}
 
 	urls := client.StationURLs()
 

--- a/secure-connection/send_report.go
+++ b/secure-connection/send_report.go
@@ -2,7 +2,6 @@ package secureconnection
 
 import (
 	"encoding/hex"
-	"fmt"
 	"strconv"
 
 	nex "github.com/PretendoNetwork/nex-go"
@@ -10,8 +9,8 @@ import (
 )
 
 func sendReport(err error, client *nex.Client, callID uint32, reportID uint32, reportData []byte) {
-	fmt.Println("Report ID: " + strconv.Itoa(int(reportID)))
-	fmt.Println("Report Data: " + hex.EncodeToString(reportData))
+	logger.Info("Report ID: " + strconv.Itoa(int(reportID)))
+	logger.Info("Report Data: " + hex.EncodeToString(reportData))
 
 	rmcResponse := nex.NewRMCResponse(secure_connection.ProtocolID, callID)
 	rmcResponse.SetSuccess(secure_connection.MethodSendReport, nil)


### PR DESCRIPTION
- Since we now store the client station URLs on nex.Client, there's no
need for external handlers to do so, so remove them. Also, the handlers
were deprecated as they didn't do anything anyway.
- Use common struct on NAT traversal and remove external handlers,
as we now store the client station URLs on nex.Client. And implement
ReportNATTraversalResult.
- Various changes to Matchmaking:
  - Use structure.Copy() and structure.Equal() now that they are
  implemented.
  - Add notification types that weren't used before.
  - Remove handlers for MatchMaking(-Ext) and use global sessions for
  handling rooms.
  - And possibly more
  
Depends on https://github.com/PretendoNetwork/nex-protocols-go/pull/24