### PR TITLE
Handle multiple station URLs on Register and more

### DIFF
--- a/globals/matchmaking_globals.go
+++ b/globals/matchmaking_globals.go
@@ -12,3 +12,4 @@ type CommonMatchmakeSession struct {
 }
 
 var Sessions map[uint32]*CommonMatchmakeSession
+var CurrentGatheringID uint32

--- a/globals/matchmaking_globals.go
+++ b/globals/matchmaking_globals.go
@@ -1,6 +1,7 @@
 package common_globals
 
 import (
+	"github.com/PretendoNetwork/nex-go"
 	match_making_types "github.com/PretendoNetwork/nex-protocols-go/match-making/types"
 )
 
@@ -12,4 +13,4 @@ type CommonMatchmakeSession struct {
 }
 
 var Sessions map[uint32]*CommonMatchmakeSession
-var CurrentGatheringID uint32
+var CurrentGatheringID = nex.NewCounter(0)

--- a/globals/matchmaking_utils.go
+++ b/globals/matchmaking_utils.go
@@ -14,12 +14,11 @@ import (
 // GetAvailableGatheringID returns a gathering ID which doesn't belong to any session
 // Returns 0 if no IDs are available (math.MaxUint32 has been reached)
 func GetAvailableGatheringID() uint32 {
-	if CurrentGatheringID == math.MaxUint32 {
+	if CurrentGatheringID.Value() == math.MaxUint32 {
 		return 0
 	}
 
-	CurrentGatheringID++
-	return CurrentGatheringID
+	return CurrentGatheringID.Increment()
 }
 
 // FindOtherConnectionID searches a connection ID on the session that isn't the given one

--- a/globals/matchmaking_utils.go
+++ b/globals/matchmaking_utils.go
@@ -14,17 +14,12 @@ import (
 // GetAvailableGatheringID returns a gathering ID which doesn't belong to any session
 // Returns 0 if no IDs are available (math.MaxUint32 has been reached)
 func GetAvailableGatheringID() uint32 {
-	var gatheringID uint32 = 1
-	for gatheringID < math.MaxUint32 {
-		// * If the session does not exist, the gathering ID is free
-		if _, ok := Sessions[gatheringID]; !ok {
-			return gatheringID
-		}
-
-		gatheringID++
+	if CurrentGatheringID == math.MaxUint32 {
+		return 0
 	}
 
-	return 0
+	CurrentGatheringID++
+	return CurrentGatheringID
 }
 
 // FindOtherConnectionID searches a connection ID on the session that isn't the given one

--- a/matchmake-extension/auto_matchmake_postpone.go
+++ b/matchmake-extension/auto_matchmake_postpone.go
@@ -118,6 +118,10 @@ func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, anyGat
 	rmcMessageBytes := rmcMessage.Bytes()
 
 	targetClient := server.FindClientFromPID(uint32(common_globals.Sessions[sessionIndex].GameMatchmakeSession.Gathering.OwnerPID))
+	if targetClient == nil {
+		logger.Warning("Owner client not found")
+		return 0
+	}
 
 	var messagePacket nex.PacketInterface
 

--- a/matchmake-extension/auto_matchmake_postpone.go
+++ b/matchmake-extension/auto_matchmake_postpone.go
@@ -10,16 +10,17 @@ import (
 )
 
 func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, anyGathering *nex.DataHolder, message string) uint32 {
+	if commonMatchmakeExtensionProtocol.cleanupSearchMatchmakeSessionHandler == nil {
+		logger.Warning("MatchmakeExtension::AutoMatchmake_Postpone missing CleanupSearchMatchmakeSessionHandler!")
+		return nex.Errors.Core.NotImplemented
+	}
+
 	if err != nil {
 		logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
 	server := commonMatchmakeExtensionProtocol.server
-	if commonMatchmakeExtensionProtocol.cleanupSearchMatchmakeSessionHandler == nil {
-		logger.Warning("MatchmakeExtension::AutoMatchmake_Postpone missing CleanupSearchMatchmakeSessionHandler!")
-		return nex.Errors.Core.Exception
-	}
 
 	// A client may disconnect from a session without leaving reliably,
 	// so let's make sure the client is removed from the session

--- a/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
@@ -11,7 +11,7 @@ import (
 
 func autoMatchmakeWithSearchCriteria_Postpone(err error, client *nex.Client, callID uint32, lstSearchCriteria []*match_making_types.MatchmakeSessionSearchCriteria, anyGathering *nex.DataHolder, message string) uint32 {
 	if commonMatchmakeExtensionProtocol.cleanupMatchmakeSessionSearchCriteriaHandler == nil {
-		logger.Warning("MatchmakeExtension::AutoMatchmake_Postpone missing CleanupMatchmakeSessionSearchCriteriaHandler!")
+		logger.Warning("MatchmakeExtension::AutoMatchmakeWithSearchCriteria_Postpone missing CleanupMatchmakeSessionSearchCriteriaHandler!")
 		return nex.Errors.Core.NotImplemented
 	}
 

--- a/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
@@ -125,6 +125,10 @@ func autoMatchmakeWithSearchCriteria_Postpone(err error, client *nex.Client, cal
 	rmcMessageBytes := rmcMessage.Bytes()
 
 	targetClient := server.FindClientFromPID(uint32(session.GameMatchmakeSession.Gathering.OwnerPID))
+	if targetClient == nil {
+		logger.Warning("Owner client not found")
+		return 0
+	}
 
 	var messagePacket nex.PacketInterface
 

--- a/matchmake-extension/close_participation.go
+++ b/matchmake-extension/close_participation.go
@@ -1,0 +1,55 @@
+package matchmake_extension
+
+import (
+	nex "github.com/PretendoNetwork/nex-go"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
+	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
+)
+
+func closeParticipation(err error, client *nex.Client, callID uint32, gid uint32) uint32 {
+	if err != nil {
+		logger.Error(err.Error())
+		return nex.Errors.Core.InvalidArgument
+	}
+
+	var session *common_globals.CommonMatchmakeSession
+	var ok bool
+	if session, ok = common_globals.Sessions[gid]; !ok {
+		return nex.Errors.RendezVous.SessionVoid
+	}
+
+	if session.GameMatchmakeSession.Gathering.OwnerPID != client.PID() {
+		return nex.Errors.RendezVous.PermissionDenied
+	}
+
+	session.GameMatchmakeSession.OpenParticipation = false
+
+	server := commonMatchmakeExtensionProtocol.server
+
+	rmcResponse := nex.NewRMCResponse(matchmake_extension.ProtocolID, callID)
+	rmcResponse.SetSuccess(matchmake_extension.MethodCloseParticipation, nil)
+
+	rmcResponseBytes := rmcResponse.Bytes()
+
+	var responsePacket nex.PacketInterface
+
+	if server.PRUDPVersion() == 0 {
+		responsePacket, _ = nex.NewPacketV0(client, nil)
+		responsePacket.SetVersion(0)
+	} else {
+		responsePacket, _ = nex.NewPacketV1(client, nil)
+		responsePacket.SetVersion(1)
+	}
+
+	responsePacket.SetSource(0xA1)
+	responsePacket.SetDestination(0xAF)
+	responsePacket.SetType(nex.DataPacket)
+	responsePacket.SetPayload(rmcResponseBytes)
+
+	responsePacket.AddFlag(nex.FlagNeedsAck)
+	responsePacket.AddFlag(nex.FlagReliable)
+
+	server.Send(responsePacket)
+
+	return 0
+}

--- a/matchmake-extension/get_simple_playing_session.go
+++ b/matchmake-extension/get_simple_playing_session.go
@@ -45,6 +45,10 @@ func getSimplePlayingSession(err error, client *nex.Client, callID uint32, listP
 				connectedPIDs := make([]uint32, 0)
 				for _, connectionID := range session.ConnectionIDs {
 					player := server.FindClientFromConnectionID(connectionID)
+					if player == nil {
+						logger.Warning("Player not found")
+						continue
+					}
 
 					connectedPIDs = append(connectedPIDs, player.PID())
 				}

--- a/matchmake-extension/join_matchmake_session_with_param.go
+++ b/matchmake-extension/join_matchmake_session_with_param.go
@@ -67,6 +67,7 @@ func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32,
 		target := server.FindClientFromConnectionID(session.ConnectionIDs[i])
 		if target == nil {
 			// TODO - Error here?
+			logger.Warning("Player not found")
 			continue
 		}
 

--- a/matchmake-extension/modify_current_game_attribute.go
+++ b/matchmake-extension/modify_current_game_attribute.go
@@ -19,6 +19,10 @@ func modifyCurrentGameAttribute(err error, client *nex.Client, callID uint32, gi
 		return nex.Errors.RendezVous.SessionVoid
 	}
 
+	if session.GameMatchmakeSession.Gathering.OwnerPID != client.PID() {
+		return nex.Errors.RendezVous.PermissionDenied
+	}
+
 	if int(attribIndex) > len(session.GameMatchmakeSession.Attributes) {
 		return nex.Errors.Core.InvalidIndex
 	}

--- a/matchmake-extension/protocol.go
+++ b/matchmake-extension/protocol.go
@@ -42,6 +42,7 @@ func initDefault(c *CommonMatchmakeExtensionProtocol) {
 	// TODO - Organize by method ID
 	c.DefaultProtocol = matchmake_extension.NewProtocol(c.server)
 	c.DefaultProtocol.OpenParticipation(openParticipation)
+	c.DefaultProtocol.CloseParticipation(closeParticipation)
 	c.DefaultProtocol.CreateMatchmakeSession(createMatchmakeSession)
 	c.DefaultProtocol.GetSimplePlayingSession(getSimplePlayingSession)
 	c.DefaultProtocol.AutoMatchmakePostpone(autoMatchmake_Postpone)
@@ -58,6 +59,7 @@ func initMarioKart8(c *CommonMatchmakeExtensionProtocol) {
 	// TODO - Organize by method ID
 	c.MarioKart8Protocol = matchmake_extension_mario_kart_8.NewProtocol(c.server)
 	c.MarioKart8Protocol.OpenParticipation(openParticipation)
+	c.MarioKart8Protocol.CloseParticipation(closeParticipation)
 	c.MarioKart8Protocol.CreateMatchmakeSession(createMatchmakeSession)
 	c.MarioKart8Protocol.GetSimplePlayingSession(getSimplePlayingSession)
 	c.MarioKart8Protocol.AutoMatchmakePostpone(autoMatchmake_Postpone)

--- a/matchmaking-ext/end_participation.go
+++ b/matchmaking-ext/end_participation.go
@@ -96,6 +96,10 @@ func endParticipation(err error, client *nex.Client, callID uint32, idGathering 
 	rmcMessageBytes := rmcMessage.Bytes()
 
 	targetClient := server.FindClientFromPID(uint32(ownerPID))
+	if targetClient == nil {
+		logger.Warning("Owner client not found")
+		return 0
+	}
 
 	var messagePacket nex.PacketInterface
 

--- a/secure-connection/register.go
+++ b/secure-connection/register.go
@@ -19,10 +19,16 @@ func register(err error, client *nex.Client, callID uint32, stationUrls []*nex.S
 	localStation := stationUrls[0]
 
 	// * A NEX client can set the public station URL by setting two URLs on the array
+	// * Check each URL for a public station
 	var publicStation *nex.StationURL
-	if len(stationUrls) > 1 {
-		publicStation = stationUrls[1]
-	} else {
+	for _, stationURL := range stationUrls {
+		if stationURL.Type() == 3 {
+			publicStation = stationURL
+			break
+		}
+	}
+
+	if publicStation == nil {
 		publicStation = localStation.Copy()
 
 		publicStation.SetAddress(client.Address().IP.String())

--- a/secure-connection/register.go
+++ b/secure-connection/register.go
@@ -17,14 +17,26 @@ func register(err error, client *nex.Client, callID uint32, stationUrls []*nex.S
 	client.SetConnectionID(nextConnectionID)
 
 	localStation := stationUrls[0]
-	publicStation := localStation.Copy()
 
-	publicStation.SetAddress(client.Address().IP.String())
-	publicStation.SetPort(uint32(client.Address().Port))
-	publicStation.SetNatf(0)
-	publicStation.SetNatm(0)
-	publicStation.SetType(3)
+	// * A NEX client can set the public station URL by setting two URLs on the array
+	var publicStation *nex.StationURL
+	if len(stationUrls) > 1 {
+		publicStation = stationUrls[1]
+	} else {
+		publicStation = localStation.Copy()
+
+		publicStation.SetAddress(client.Address().IP.String())
+		publicStation.SetPort(uint32(client.Address().Port))
+		publicStation.SetNatf(0)
+		publicStation.SetNatm(0)
+		publicStation.SetType(3)
+	}
+
+	localStation.SetPID(client.PID())
 	publicStation.SetPID(client.PID())
+
+	localStation.SetRVCID(client.ConnectionID())
+	publicStation.SetRVCID(client.ConnectionID())
 
 	localStation.SetLocal()
 	publicStation.SetPublic()


### PR DESCRIPTION
- Games like Mario Kart 7 or Mario Tennis Open set the local station and
the public station. In these cases, use the public station given by the client.
- Add the PID and RVCID on both stations, as they are required on NAT
traversal and not all games will call `ReportNATProperties` to add them.
- Implement `MatchmakeExtension::CloseParticipation`
- and more