### PR TITLE
Redesign find sessions using SearchCriteria

### DIFF
--- a/globals/globals.go
+++ b/globals/globals.go
@@ -1,0 +1,7 @@
+package common_globals
+
+import (
+	"github.com/PretendoNetwork/plogger-go"
+)
+
+var Logger = plogger.NewLogger()

--- a/globals/matchmaking_globals.go
+++ b/globals/matchmaking_globals.go
@@ -8,10 +8,10 @@ import (
 type CommonMatchmakeSession struct {
 	GameMatchmakeSession   *match_making_types.MatchmakeSession                 // * Used by the game, contains the current state of the MatchmakeSession
 	SearchMatchmakeSession *match_making_types.MatchmakeSession                 // * Used by the server when searching for matches, contains the state of the MatchmakeSession during the search process for easy compares
-	SearchCriteria         []*match_making_types.MatchmakeSessionSearchCriteria // * Used by the server when searching for matches, contains the list of MatchmakeSessionSearchCriteria
 	ConnectionIDs          []uint32                                             // * Players in the room, referenced by their connection IDs. This is used instead of the PID in order to ensure we're talking to the correct client (in case of e.g. multiple logins)
 }
 
 var Sessions map[uint32]*CommonMatchmakeSession
+var GetUserFriendPIDsHandler func(pid uint32) []uint32
 var CurrentGatheringID = nex.NewCounter(0)
 var CurrentMatchmakingCallID = nex.NewCounter(0)

--- a/globals/matchmaking_utils.go
+++ b/globals/matchmaking_utils.go
@@ -111,8 +111,7 @@ func RemoveClientFromAllSessions(client *nex.Client) {
 
 			targetClient := server.FindClientFromPID(uint32(ownerPID))
 			if targetClient == nil {
-				// TODO - We don't have a logger here
-				// logger.Warning("Owner client not found")
+				Logger.Warning("Owner client not found")
 				gid = FindClientSession(client.ConnectionID())
 				continue
 			}
@@ -211,8 +210,7 @@ func FindSessionByMatchmakeSession(pid uint32, searchMatchmakeSession *match_mak
 		// TODO - Is this a flag or a constant?
 		if sessionToCheck.GameMatchmakeSession.ParticipationPolicy == 98 {
 			if GetUserFriendPIDsHandler == nil {
-				// TODO - We don't have a logger here
-				// logger.Warning("Missing GetUserFriendPIDsHandler!")
+				Logger.Warning("Missing GetUserFriendPIDsHandler!")
 				continue
 			}
 
@@ -272,8 +270,7 @@ func FindSessionsByMatchmakeSessionSearchCriterias(pid uint32, lstSearchCriteria
 			// TODO - Is this a flag or a constant?
 			if session.GameMatchmakeSession.ParticipationPolicy == 98 {
 				if GetUserFriendPIDsHandler == nil {
-					// TODO - We don't have a logger here
-					// logger.Warning("Missing GetUserFriendPIDsHandler!")
+					Logger.Warning("Missing GetUserFriendPIDsHandler!")
 					continue
 				}
 
@@ -364,7 +361,7 @@ func AddPlayersToSession(session *CommonMatchmakeSession, connectionIDs []uint32
 		target := server.FindClientFromConnectionID(session.ConnectionIDs[i])
 		if target == nil {
 			// TODO - Error here?
-			//logger.Warning("Player not found")
+			Logger.Warning("Player not found")
 			continue
 		}
 
@@ -420,7 +417,7 @@ func AddPlayersToSession(session *CommonMatchmakeSession, connectionIDs []uint32
 			target := server.FindClientFromConnectionID(session.ConnectionIDs[i])
 			if target == nil {
 				// TODO - Error here?
-				//logger.Warning("Player not found")
+				Logger.Warning("Player not found")
 				continue
 			}
 
@@ -514,7 +511,7 @@ func AddPlayersToSession(session *CommonMatchmakeSession, connectionIDs []uint32
 		target := server.FindClientFromPID(uint32(session.GameMatchmakeSession.Gathering.OwnerPID))
 		if target == nil {
 			// TODO - Error here?
-			//logger.Warning("Player not found")
+			Logger.Warning("Player not found")
 			return nil, 0
 		}
 
@@ -551,8 +548,7 @@ func ChangeSessionOwner(ownerClient *nex.Client, gathering uint32) {
 		if otherClient != nil {
 			Sessions[gathering].GameMatchmakeSession.Gathering.OwnerPID = otherClient.PID()
 		} else {
-			// TODO - We don't have a logger here
-			// logger.Warning("Other client not found")
+			Logger.Warning("Other client not found")
 			return
 		}
 	} else {
@@ -607,8 +603,7 @@ func ChangeSessionOwner(ownerClient *nex.Client, gathering uint32) {
 
 			server.Send(messagePacket)
 		} else {
-			// TODO - We don't have a logger here
-			// logger.Warning("Client not found")
+			Logger.Warning("Client not found")
 		}
 	}
 }

--- a/globals/matchmaking_utils.go
+++ b/globals/matchmaking_utils.go
@@ -163,13 +163,29 @@ func CreateSessionByMatchmakeSession(matchmakeSession *match_making_types.Matchm
 	session.GameMatchmakeSession.SessionKey = make([]byte, 32)
 	rand.Read(session.GameMatchmakeSession.SessionKey)
 
+	if session.GameMatchmakeSession.MatchmakeParam == nil {
+		session.GameMatchmakeSession.MatchmakeParam = match_making_types.NewMatchmakeParam()
+	}
+
+	if session.GameMatchmakeSession.MatchmakeParam.Parameters == nil {
+		session.GameMatchmakeSession.MatchmakeParam.Parameters = make(map[string]*nex.Variant)
+	}
+
+	session.GameMatchmakeSession.MatchmakeParam.Parameters["@SR"] = nex.NewVariant()
+	session.GameMatchmakeSession.MatchmakeParam.Parameters["@SR"].TypeID = 3
+	session.GameMatchmakeSession.MatchmakeParam.Parameters["@SR"].Bool = true
+
+	session.GameMatchmakeSession.MatchmakeParam.Parameters["@GIR"] = nex.NewVariant()
+	session.GameMatchmakeSession.MatchmakeParam.Parameters["@GIR"].TypeID = 1
+	session.GameMatchmakeSession.MatchmakeParam.Parameters["@GIR"].Int64 = 3
+
 	Sessions[sessionIndex] = &session
 
 	return Sessions[sessionIndex], nil, 0
 }
 
 // FindSessionByMatchmakeSession finds a gathering that matches with a MatchmakeSession
-func FindSessionByMatchmakeSession(searchMatchmakeSession *match_making_types.MatchmakeSession) uint32 {
+func FindSessionByMatchmakeSession(pid uint32, searchMatchmakeSession *match_making_types.MatchmakeSession) uint32 {
 	// * This portion finds any sessions that match the search session
 	// * It does not care about anything beyond that, such as if the match is already full
 	// * This is handled below
@@ -180,6 +196,7 @@ func FindSessionByMatchmakeSession(searchMatchmakeSession *match_making_types.Ma
 		}
 	}
 
+	var friendList []uint32
 	for _, sessionIndex := range candidateSessionIndexes {
 		sessionToCheck := Sessions[sessionIndex]
 		if len(sessionToCheck.ConnectionIDs) >= int(sessionToCheck.GameMatchmakeSession.MaximumParticipants) {
@@ -190,144 +207,137 @@ func FindSessionByMatchmakeSession(searchMatchmakeSession *match_making_types.Ma
 			continue
 		}
 
+		// If the session only allows friends, check if the owner is in the friend list of the PID
+		// TODO - Is this a flag or a constant?
+		if sessionToCheck.GameMatchmakeSession.ParticipationPolicy == 98 {
+			if GetUserFriendPIDsHandler == nil {
+				// TODO - We don't have a logger here
+				// logger.Warning("Missing GetUserFriendPIDsHandler!")
+				continue
+			}
+
+			if len(friendList) == 0 {
+				friendList = GetUserFriendPIDsHandler(pid)
+			}
+
+			if !slices.Contains(friendList, sessionToCheck.GameMatchmakeSession.OwnerPID) {
+				continue
+			}
+		}
+
 		return sessionIndex // * Found a match
 	}
 
 	return 0
 }
 
-// CreateSessionBySearchCriteria creates a gathering from MatchmakeSessionSearchCriteria
-func CreateSessionBySearchCriteria(matchmakeSession *match_making_types.MatchmakeSession, lstSearchCriteria []*match_making_types.MatchmakeSessionSearchCriteria, hostPID uint32) (*CommonMatchmakeSession, error, uint32) {
-	sessionIndex := GetAvailableGatheringID()
-	if sessionIndex == 0 {
-		CurrentGatheringID = nex.NewCounter(0)
-		sessionIndex = GetAvailableGatheringID()
+// FindSessionsByMatchmakeSessionSearchCriterias finds a gathering that matches with the given search criteria
+func FindSessionsByMatchmakeSessionSearchCriterias(pid uint32, lstSearchCriteria []*match_making_types.MatchmakeSessionSearchCriteria, gameSpecificChecks func(searchCriteria *match_making_types.MatchmakeSessionSearchCriteria, matchmakeSession *match_making_types.MatchmakeSession) bool) []*CommonMatchmakeSession {
+	candidateSessions := make([]*CommonMatchmakeSession, 0, len(Sessions))
+	var friendList []uint32
+	for _, session := range Sessions {
+		for _, searchCriteria := range lstSearchCriteria {
+			// * Check things like game specific attributes
+			if gameSpecificChecks != nil {
+				if !gameSpecificChecks(searchCriteria, session.GameMatchmakeSession) {
+					continue
+				}
+			} else {
+				if !compareAttributesSearchCriteria(session.GameMatchmakeSession.Attributes, searchCriteria.Attribs) {
+					continue
+				}
+			}
+
+			if !compareSearchCriteria(session.GameMatchmakeSession.MaximumParticipants, searchCriteria.MaxParticipants) {
+				continue
+			}
+
+			if !compareSearchCriteria(session.GameMatchmakeSession.MinimumParticipants, searchCriteria.MinParticipants) {
+				continue
+			}
+
+			if !compareSearchCriteria(session.GameMatchmakeSession.GameMode, searchCriteria.GameMode) {
+				continue
+			}
+
+			if len(session.ConnectionIDs) >= int(session.GameMatchmakeSession.MaximumParticipants) {
+				continue
+			}
+
+			if !session.GameMatchmakeSession.OpenParticipation {
+				continue
+			}
+
+			// If the session only allows friends, check if the owner is in the friend list of the PID
+			// TODO - Is this a flag or a constant?
+			if session.GameMatchmakeSession.ParticipationPolicy == 98 {
+				if GetUserFriendPIDsHandler == nil {
+					// TODO - We don't have a logger here
+					// logger.Warning("Missing GetUserFriendPIDsHandler!")
+					continue
+				}
+
+				if len(friendList) == 0 {
+					friendList = GetUserFriendPIDsHandler(pid)
+				}
+
+				if !slices.Contains(friendList, session.GameMatchmakeSession.OwnerPID) {
+					continue
+				}
+			}
+
+			candidateSessions = append(candidateSessions, session)
+
+			// We don't have to compare with other search criterias
+			break
+		}
 	}
 
-	session := CommonMatchmakeSession{
-		SearchCriteria:       lstSearchCriteria,
-		GameMatchmakeSession: matchmakeSession,
-	}
-
-	session.GameMatchmakeSession.Gathering.ID = sessionIndex
-	session.GameMatchmakeSession.Gathering.OwnerPID = hostPID
-	session.GameMatchmakeSession.Gathering.HostPID = hostPID
-
-	session.GameMatchmakeSession.StartedTime = nex.NewDateTime(0)
-	session.GameMatchmakeSession.StartedTime.UTC()
-	session.GameMatchmakeSession.SessionKey = make([]byte, 32)
-	rand.Read(session.GameMatchmakeSession.SessionKey)
-
-	Sessions[sessionIndex] = &session
-
-	return Sessions[sessionIndex], nil, 0
+	return candidateSessions
 }
 
-// FindSessionsByMatchmakeSessionSearchCriterias finds a gathering that matches with a MatchmakeSession
-func FindSessionsByMatchmakeSessionSearchCriterias(lstSearchCriteria []*match_making_types.MatchmakeSessionSearchCriteria, gameSpecificChecks func(requestSearchCriteria, sessionSearchCriteria *match_making_types.MatchmakeSessionSearchCriteria) bool) []*CommonMatchmakeSession {
-	// * This portion finds any sessions that match the search session
-	// * It does not care about anything beyond that, such as if the match is already full
-	// * This is handled below.
-	candidateSessions := make([]*CommonMatchmakeSession, 0, len(Sessions))
+func compareAttributesSearchCriteria(original []uint32, search []string) bool {
+	if len(original) != len(search) {
+		return false
+	}
 
-	for _, session := range Sessions {
-		if len(lstSearchCriteria) == len(session.SearchCriteria) {
-			for criteriaIndex, sessionSearchCriteria := range session.SearchCriteria {
-				requestSearchCriteria := lstSearchCriteria[criteriaIndex]
+	for index, originalAttribute := range original {
+		searchAttribute := search[index]
 
-				// * Check things like game specific attributes
-				if gameSpecificChecks != nil && !gameSpecificChecks(lstSearchCriteria[criteriaIndex], sessionSearchCriteria) {
-					continue
-				}
-
-				if requestSearchCriteria.GameMode != "" && requestSearchCriteria.GameMode != sessionSearchCriteria.GameMode {
-					continue
-				}
-
-				if requestSearchCriteria.MinParticipants != "" {
-					split := strings.Split(requestSearchCriteria.MinParticipants, ",")
-					minStr, maxStr := split[0], split[1]
-
-					if minStr != "" {
-						min, err := strconv.Atoi(minStr)
-						if err != nil {
-							// TODO - We don't have a logger here
-							continue
-						}
-
-						if session.GameMatchmakeSession.MinimumParticipants < uint16(min) {
-							continue
-						}
-					}
-
-					if maxStr != "" {
-						max, err := strconv.Atoi(maxStr)
-						if err != nil {
-							// TODO - We don't have a logger here
-							continue
-						}
-
-						if session.GameMatchmakeSession.MinimumParticipants > uint16(max) {
-							continue
-						}
-					}
-				}
-
-				if requestSearchCriteria.MaxParticipants != "" {
-					split := strings.Split(requestSearchCriteria.MaxParticipants, ",")
-					minStr := split[0]
-					maxStr := ""
-
-					if len(split) > 1 {
-						maxStr = split[1]
-					}
-
-					if minStr != "" {
-						min, err := strconv.Atoi(minStr)
-						if err != nil {
-							// TODO - We don't have a logger here
-							continue
-						}
-
-						if session.GameMatchmakeSession.MaximumParticipants < uint16(min) {
-							continue
-						}
-					}
-
-					if maxStr != "" {
-						max, err := strconv.Atoi(maxStr)
-						if err != nil {
-							// TODO - We don't have a logger here
-							continue
-						}
-
-						if session.GameMatchmakeSession.MaximumParticipants > uint16(max) {
-							continue
-						}
-					}
-				}
-
-				candidateSessions = append(candidateSessions, session)
-			}
+		if !compareSearchCriteria(originalAttribute, searchAttribute) {
+			return false
 		}
 	}
 
-	filteredSessions := make([]*CommonMatchmakeSession, 0, len(candidateSessions))
+	return true
+}
 
-	// * Further filter the candidate sessions
-	for _, session := range candidateSessions {
-		if len(session.ConnectionIDs) >= int(session.GameMatchmakeSession.MaximumParticipants) {
-			continue
-		}
-
-		if !session.GameMatchmakeSession.OpenParticipation {
-			continue
-		}
-
-		filteredSessions = append(filteredSessions, session) // * Found a match
+func compareSearchCriteria[T ~uint16 | ~uint32](original T, search string) bool {
+	if search == "" { // Accept any value
+		return true
 	}
 
-	return filteredSessions
+	before, after, found := strings.Cut(search, ",")
+	if found {
+		min, err := strconv.ParseUint(before, 10, 64)
+		if err != nil {
+			return false
+		}
+
+		max, err := strconv.ParseUint(after, 10, 64)
+		if err != nil {
+			return false
+		}
+
+		return min <= uint64(original) && max >= uint64(original)
+	} else {
+		searchNum, err := strconv.ParseUint(before, 10, 64)
+		if err != nil {
+			return false
+		}
+
+		return searchNum == uint64(original)
+	}
 }
 
 // AddPlayersToSession updates the given sessions state to include the provided connection IDs

--- a/matchmake-extension/auto_matchmake_postpone.go
+++ b/matchmake-extension/auto_matchmake_postpone.go
@@ -9,12 +9,12 @@ import (
 
 func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, anyGathering *nex.DataHolder, message string) uint32 {
 	if commonMatchmakeExtensionProtocol.cleanupSearchMatchmakeSessionHandler == nil {
-		logger.Warning("MatchmakeExtension::AutoMatchmake_Postpone missing CleanupSearchMatchmakeSessionHandler!")
+		common_globals.Logger.Warning("MatchmakeExtension::AutoMatchmake_Postpone missing CleanupSearchMatchmakeSessionHandler!")
 		return nex.Errors.Core.NotImplemented
 	}
 
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -30,7 +30,7 @@ func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, anyGat
 	if anyGatheringDataType == "MatchmakeSession" {
 		matchmakeSession = anyGathering.ObjectData().(*match_making_types.MatchmakeSession)
 	} else {
-		logger.Critical("Non-MatchmakeSession DataType?!")
+		common_globals.Logger.Critical("Non-MatchmakeSession DataType?!")
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -43,7 +43,7 @@ func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, anyGat
 		var errCode uint32
 		session, err, errCode = common_globals.CreateSessionByMatchmakeSession(matchmakeSession, searchMatchmakeSession, client.PID())
 		if err != nil {
-			logger.Error(err.Error())
+			common_globals.Logger.Error(err.Error())
 			return errCode
 		}
 	} else {
@@ -52,7 +52,7 @@ func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, anyGat
 
 	err, errCode := common_globals.AddPlayersToSession(session, []uint32{client.ConnectionID()}, client, message)
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return errCode
 	}
 

--- a/matchmake-extension/auto_matchmake_postpone.go
+++ b/matchmake-extension/auto_matchmake_postpone.go
@@ -36,7 +36,7 @@ func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, anyGat
 
 	searchMatchmakeSession := matchmakeSession.Copy().(*match_making_types.MatchmakeSession)
 	commonMatchmakeExtensionProtocol.cleanupSearchMatchmakeSessionHandler(searchMatchmakeSession)
-	sessionIndex := common_globals.FindSessionByMatchmakeSession(searchMatchmakeSession)
+	sessionIndex := common_globals.FindSessionByMatchmakeSession(client.PID(), searchMatchmakeSession)
 	var session *common_globals.CommonMatchmakeSession
 
 	if sessionIndex == 0 {

--- a/matchmake-extension/auto_matchmake_with_param_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_param_postpone.go
@@ -9,7 +9,7 @@ import (
 
 func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint32, autoMatchmakeParam *match_making_types.AutoMatchmakeParam) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -29,7 +29,7 @@ func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint3
 		var errCode uint32
 		session, err, errCode = common_globals.CreateSessionByMatchmakeSession(matchmakeSession, nil, client.PID())
 		if err != nil {
-			logger.Error(err.Error())
+			common_globals.Logger.Error(err.Error())
 			return errCode
 		}
 	} else {
@@ -38,7 +38,7 @@ func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint3
 
 	err, errCode := common_globals.AddPlayersToSession(session, []uint32{client.ConnectionID()}, client, "")
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return errCode
 	}
 

--- a/matchmake-extension/auto_matchmake_with_param_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_param_postpone.go
@@ -8,11 +8,6 @@ import (
 )
 
 func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint32, autoMatchmakeParam *match_making_types.AutoMatchmakeParam) uint32 {
-	if commonMatchmakeExtensionProtocol.cleanupMatchmakeSessionSearchCriteriaHandler == nil {
-		logger.Warning("MatchmakeExtension::AutoMatchmake_Postpone missing CleanupSearchMatchmakeSessionHandler!")
-		return nex.Errors.Core.NotImplemented
-	}
-
 	if err != nil {
 		logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
@@ -27,14 +22,12 @@ func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint3
 	var matchmakeSession *match_making_types.MatchmakeSession
 	matchmakeSession = autoMatchmakeParam.SourceMatchmakeSession
 
-	commonMatchmakeExtensionProtocol.cleanupMatchmakeSessionSearchCriteriaHandler(autoMatchmakeParam.LstSearchCriteria)
-
-	sessions := common_globals.FindSessionsByMatchmakeSessionSearchCriterias(autoMatchmakeParam.LstSearchCriteria, commonMatchmakeExtensionProtocol.gameSpecificMatchmakeSessionSearchCriteriaChecksHandler)
+	sessions := common_globals.FindSessionsByMatchmakeSessionSearchCriterias(client.PID(), autoMatchmakeParam.LstSearchCriteria, commonMatchmakeExtensionProtocol.gameSpecificMatchmakeSessionSearchCriteriaChecksHandler)
 	var session *common_globals.CommonMatchmakeSession
 
 	if len(sessions) == 0 {
 		var errCode uint32
-		session, err, errCode = common_globals.CreateSessionBySearchCriteria(matchmakeSession, autoMatchmakeParam.LstSearchCriteria, client.PID())
+		session, err, errCode = common_globals.CreateSessionByMatchmakeSession(matchmakeSession, nil, client.PID())
 		if err != nil {
 			logger.Error(err.Error())
 			return errCode

--- a/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
@@ -9,7 +9,7 @@ import (
 
 func autoMatchmakeWithSearchCriteria_Postpone(err error, client *nex.Client, callID uint32, lstSearchCriteria []*match_making_types.MatchmakeSessionSearchCriteria, anyGathering *nex.DataHolder, message string) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -25,7 +25,7 @@ func autoMatchmakeWithSearchCriteria_Postpone(err error, client *nex.Client, cal
 	if anyGatheringDataType == "MatchmakeSession" {
 		matchmakeSession = anyGathering.ObjectData().(*match_making_types.MatchmakeSession)
 	} else {
-		logger.Critical("Non-MatchmakeSession DataType?!")
+		common_globals.Logger.Critical("Non-MatchmakeSession DataType?!")
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -36,7 +36,7 @@ func autoMatchmakeWithSearchCriteria_Postpone(err error, client *nex.Client, cal
 		var errCode uint32
 		session, err, errCode = common_globals.CreateSessionByMatchmakeSession(matchmakeSession, nil, client.PID())
 		if err != nil {
-			logger.Error(err.Error())
+			common_globals.Logger.Error(err.Error())
 			return errCode
 		}
 	} else {
@@ -45,7 +45,7 @@ func autoMatchmakeWithSearchCriteria_Postpone(err error, client *nex.Client, cal
 
 	err, errCode := common_globals.AddPlayersToSession(session, []uint32{client.ConnectionID()}, client, message)
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return errCode
 	}
 

--- a/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
@@ -8,17 +8,10 @@ import (
 )
 
 func autoMatchmakeWithSearchCriteria_Postpone(err error, client *nex.Client, callID uint32, lstSearchCriteria []*match_making_types.MatchmakeSessionSearchCriteria, anyGathering *nex.DataHolder, message string) uint32 {
-	if commonMatchmakeExtensionProtocol.cleanupMatchmakeSessionSearchCriteriaHandler == nil {
-		logger.Warning("MatchmakeExtension::AutoMatchmakeWithSearchCriteria_Postpone missing CleanupMatchmakeSessionSearchCriteriaHandler!")
-		return nex.Errors.Core.NotImplemented
-	}
-
 	if err != nil {
 		logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
-
-	commonMatchmakeExtensionProtocol.cleanupMatchmakeSessionSearchCriteriaHandler(lstSearchCriteria)
 
 	server := commonMatchmakeExtensionProtocol.server
 
@@ -36,12 +29,12 @@ func autoMatchmakeWithSearchCriteria_Postpone(err error, client *nex.Client, cal
 		return nex.Errors.Core.InvalidArgument
 	}
 
-	sessions := common_globals.FindSessionsByMatchmakeSessionSearchCriterias(lstSearchCriteria, commonMatchmakeExtensionProtocol.gameSpecificMatchmakeSessionSearchCriteriaChecksHandler)
+	sessions := common_globals.FindSessionsByMatchmakeSessionSearchCriterias(client.PID(), lstSearchCriteria, commonMatchmakeExtensionProtocol.gameSpecificMatchmakeSessionSearchCriteriaChecksHandler)
 	var session *common_globals.CommonMatchmakeSession
 
 	if len(sessions) == 0 {
 		var errCode uint32
-		session, err, errCode = common_globals.CreateSessionBySearchCriteria(matchmakeSession, lstSearchCriteria, client.PID())
+		session, err, errCode = common_globals.CreateSessionByMatchmakeSession(matchmakeSession, nil, client.PID())
 		if err != nil {
 			logger.Error(err.Error())
 			return errCode

--- a/matchmake-extension/browse_matchmake_session.go
+++ b/matchmake-extension/browse_matchmake_session.go
@@ -8,11 +8,6 @@ import (
 )
 
 func browseMatchmakeSession(err error, client *nex.Client, callID uint32, searchCriteria *match_making_types.MatchmakeSessionSearchCriteria, resultRange *nex.ResultRange) uint32 {
-	if commonMatchmakeExtensionProtocol.cleanupMatchmakeSessionSearchCriteriaHandler == nil {
-		logger.Warning("MatchmakeExtension::BrowseMatchmakeSession missing CleanupMatchmakeSessionSearchCriteriaHandler!")
-		return nex.Errors.Core.NotImplemented
-	}
-
 	if err != nil {
 		logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
@@ -21,9 +16,7 @@ func browseMatchmakeSession(err error, client *nex.Client, callID uint32, search
 	server := commonMatchmakeExtensionProtocol.server
 	searchCriterias := []*match_making_types.MatchmakeSessionSearchCriteria{searchCriteria}
 
-	commonMatchmakeExtensionProtocol.cleanupMatchmakeSessionSearchCriteriaHandler(searchCriterias)
-
-	sessions := common_globals.FindSessionsByMatchmakeSessionSearchCriterias(searchCriterias, commonMatchmakeExtensionProtocol.gameSpecificMatchmakeSessionSearchCriteriaChecksHandler)
+	sessions := common_globals.FindSessionsByMatchmakeSessionSearchCriterias(client.PID(), searchCriterias, commonMatchmakeExtensionProtocol.gameSpecificMatchmakeSessionSearchCriteriaChecksHandler)
 
 	if len(sessions) < int(resultRange.Offset) {
 		return nex.Errors.Core.InvalidIndex

--- a/matchmake-extension/browse_matchmake_session.go
+++ b/matchmake-extension/browse_matchmake_session.go
@@ -9,7 +9,7 @@ import (
 
 func browseMatchmakeSession(err error, client *nex.Client, callID uint32, searchCriteria *match_making_types.MatchmakeSessionSearchCriteria, resultRange *nex.ResultRange) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/matchmake-extension/close_participation.go
+++ b/matchmake-extension/close_participation.go
@@ -8,7 +8,7 @@ import (
 
 func closeParticipation(err error, client *nex.Client, callID uint32, gid uint32) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/matchmake-extension/create_matchmake_session.go
+++ b/matchmake-extension/create_matchmake_session.go
@@ -29,7 +29,7 @@ func createMatchmakeSession(err error, client *nex.Client, callID uint32, anyGat
 		return nex.Errors.Core.InvalidArgument
 	}
 
-	session, err, errCode := common_globals.CreateSessionBySearchCriteria(matchmakeSession, make([]*match_making_types.MatchmakeSessionSearchCriteria, 0), client.PID())
+	session, err, errCode := common_globals.CreateSessionByMatchmakeSession(matchmakeSession, nil, client.PID())
 	if err != nil {
 		logger.Error(err.Error())
 		return errCode

--- a/matchmake-extension/create_matchmake_session.go
+++ b/matchmake-extension/create_matchmake_session.go
@@ -9,7 +9,7 @@ import (
 
 func createMatchmakeSession(err error, client *nex.Client, callID uint32, anyGathering *nex.DataHolder, message string, participationCount uint16) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -25,19 +25,19 @@ func createMatchmakeSession(err error, client *nex.Client, callID uint32, anyGat
 	if anyGatheringDataType == "MatchmakeSession" {
 		matchmakeSession = anyGathering.ObjectData().(*match_making_types.MatchmakeSession)
 	} else {
-		logger.Critical("Non-MatchmakeSession DataType?!")
+		common_globals.Logger.Critical("Non-MatchmakeSession DataType?!")
 		return nex.Errors.Core.InvalidArgument
 	}
 
 	session, err, errCode := common_globals.CreateSessionByMatchmakeSession(matchmakeSession, nil, client.PID())
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return errCode
 	}
 
 	err, errCode = common_globals.AddPlayersToSession(session, []uint32{client.ConnectionID()}, client, message)
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return errCode
 	}
 

--- a/matchmake-extension/create_matchmake_session_with_param.go
+++ b/matchmake-extension/create_matchmake_session_with_param.go
@@ -9,7 +9,7 @@ import (
 
 func createMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32, createMatchmakeSessionParam *match_making_types.CreateMatchmakeSessionParam) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -22,13 +22,13 @@ func createMatchmakeSessionWithParam(err error, client *nex.Client, callID uint3
 	joinedMatchmakeSession := createMatchmakeSessionParam.SourceMatchmakeSession.Copy().(*match_making_types.MatchmakeSession)
 	session, err, errCode := common_globals.CreateSessionByMatchmakeSession(joinedMatchmakeSession, nil, client.PID())
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return errCode
 	}
 
 	err, errCode = common_globals.AddPlayersToSession(session, []uint32{client.ConnectionID()}, client, createMatchmakeSessionParam.JoinMessage)
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return errCode
 	}
 

--- a/matchmake-extension/create_matchmake_session_with_param.go
+++ b/matchmake-extension/create_matchmake_session_with_param.go
@@ -20,7 +20,7 @@ func createMatchmakeSessionWithParam(err error, client *nex.Client, callID uint3
 	common_globals.RemoveClientFromAllSessions(client)
 
 	joinedMatchmakeSession := createMatchmakeSessionParam.SourceMatchmakeSession.Copy().(*match_making_types.MatchmakeSession)
-	session, err, errCode := common_globals.CreateSessionBySearchCriteria(joinedMatchmakeSession, make([]*match_making_types.MatchmakeSessionSearchCriteria, 0), client.PID())
+	session, err, errCode := common_globals.CreateSessionByMatchmakeSession(joinedMatchmakeSession, nil, client.PID())
 	if err != nil {
 		logger.Error(err.Error())
 		return errCode

--- a/matchmake-extension/get_simple_playing_session.go
+++ b/matchmake-extension/get_simple_playing_session.go
@@ -22,7 +22,7 @@ func remove[T comparable](l []T, item T) []T {
 
 func getSimplePlayingSession(err error, client *nex.Client, callID uint32, listPID []uint32, includeLoginUser bool) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -46,7 +46,7 @@ func getSimplePlayingSession(err error, client *nex.Client, callID uint32, listP
 				for _, connectionID := range session.ConnectionIDs {
 					player := server.FindClientFromConnectionID(connectionID)
 					if player == nil {
-						logger.Warning("Player not found")
+						common_globals.Logger.Warning("Player not found")
 						continue
 					}
 

--- a/matchmake-extension/join_matchmake_session.go
+++ b/matchmake-extension/join_matchmake_session.go
@@ -8,7 +8,7 @@ import (
 
 func joinMatchmakeSession(err error, client *nex.Client, callID uint32, gid uint32, strMessage string) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -23,7 +23,7 @@ func joinMatchmakeSession(err error, client *nex.Client, callID uint32, gid uint
 
 	err, errCode := common_globals.AddPlayersToSession(session, []uint32{client.ConnectionID()}, client, strMessage)
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return errCode
 	}
 

--- a/matchmake-extension/join_matchmake_session_with_param.go
+++ b/matchmake-extension/join_matchmake_session_with_param.go
@@ -9,7 +9,7 @@ import (
 
 func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32, joinMatchmakeSessionParam *match_making_types.JoinMatchmakeSessionParam) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -23,7 +23,7 @@ func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32,
 	// TODO - More checks here
 	err, errCode := common_globals.AddPlayersToSession(session, []uint32{client.ConnectionID()}, client, joinMatchmakeSessionParam.JoinMessage)
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return errCode
 	}
 

--- a/matchmake-extension/modify_current_game_attribute.go
+++ b/matchmake-extension/modify_current_game_attribute.go
@@ -8,7 +8,7 @@ import (
 
 func modifyCurrentGameAttribute(err error, client *nex.Client, callID uint32, gid uint32, attribIndex uint32, newValue uint32) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/matchmake-extension/open_participation.go
+++ b/matchmake-extension/open_participation.go
@@ -8,7 +8,7 @@ import (
 
 func openParticipation(err error, client *nex.Client, callID uint32, gid uint32) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/matchmake-extension/protocol.go
+++ b/matchmake-extension/protocol.go
@@ -7,13 +7,11 @@ import (
 	match_making_types "github.com/PretendoNetwork/nex-protocols-go/match-making/types"
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 	matchmake_extension_mario_kart_8 "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension/mario-kart-8"
-	"github.com/PretendoNetwork/plogger-go"
 
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 var commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol
-var logger = plogger.NewLogger()
 
 type CommonMatchmakeExtensionProtocol struct {
 	server             *nex.Server
@@ -77,14 +75,14 @@ func NewCommonMatchmakeExtensionProtocol(server *nex.Server) *CommonMatchmakeExt
 	patch := server.MatchMakingProtocolVersion().GameSpecificPatch
 
 	if strings.EqualFold(patch, "AMKJ") {
-		logger.Info("Using Mario Kart 8 MatchmakeExtension protocol")
+		common_globals.Logger.Info("Using Mario Kart 8 MatchmakeExtension protocol")
 		initMarioKart8(commonMatchmakeExtensionProtocol)
 	} else {
 		if patch != "" {
-			logger.Infof("Matchmaking version patch %q not recognized", patch)
+			common_globals.Logger.Infof("Matchmaking version patch %q not recognized", patch)
 		}
 
-		logger.Info("Using default MatchmakeExtension protocol")
+		common_globals.Logger.Info("Using default MatchmakeExtension protocol")
 		initDefault(commonMatchmakeExtensionProtocol)
 	}
 

--- a/matchmake-extension/protocol.go
+++ b/matchmake-extension/protocol.go
@@ -8,6 +8,8 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 	matchmake_extension_mario_kart_8 "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension/mario-kart-8"
 	"github.com/PretendoNetwork/plogger-go"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 var commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol
@@ -19,8 +21,7 @@ type CommonMatchmakeExtensionProtocol struct {
 	MarioKart8Protocol *matchmake_extension_mario_kart_8.Protocol
 
 	cleanupSearchMatchmakeSessionHandler                    func(matchmakeSession *match_making_types.MatchmakeSession)
-	cleanupMatchmakeSessionSearchCriteriaHandler            func(lstSearchCriteria []*match_making_types.MatchmakeSessionSearchCriteria)
-	gameSpecificMatchmakeSessionSearchCriteriaChecksHandler func(requestSearchCriteria, sessionSearchCriteria *match_making_types.MatchmakeSessionSearchCriteria) bool
+	gameSpecificMatchmakeSessionSearchCriteriaChecksHandler func(searchCriteria *match_making_types.MatchmakeSessionSearchCriteria, matchmakeSession *match_making_types.MatchmakeSession) bool
 }
 
 // CleanupSearchMatchmakeSession sets the CleanupSearchMatchmakeSession handler function
@@ -28,14 +29,14 @@ func (commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol) Cleanu
 	commonMatchmakeExtensionProtocol.cleanupSearchMatchmakeSessionHandler = handler
 }
 
-// CleanupMatchmakeSessionSearchCriteria sets the CleanupMatchmakeSessionSearchCriteria handler function
-func (commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol) CleanupMatchmakeSessionSearchCriteria(handler func(lstSearchCriteria []*match_making_types.MatchmakeSessionSearchCriteria)) {
-	commonMatchmakeExtensionProtocol.cleanupMatchmakeSessionSearchCriteriaHandler = handler
+// GameSpecificMatchmakeSessionSearchCriteriaChecks sets the GameSpecificMatchmakeSessionSearchCriteriaChecks handler function
+func (commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol) GameSpecificMatchmakeSessionSearchCriteriaChecks(handler func(searchCriteria *match_making_types.MatchmakeSessionSearchCriteria, matchmakeSession *match_making_types.MatchmakeSession) bool) {
+	commonMatchmakeExtensionProtocol.gameSpecificMatchmakeSessionSearchCriteriaChecksHandler = handler
 }
 
-// GameSpecificMatchmakeSessionSearchCriteriaChecks sets the GameSpecificMatchmakeSessionSearchCriteriaChecks handler function
-func (commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol) GameSpecificMatchmakeSessionSearchCriteriaChecks(handler func(requestSearchCriteria, sessionSearchCriteria *match_making_types.MatchmakeSessionSearchCriteria) bool) {
-	commonMatchmakeExtensionProtocol.gameSpecificMatchmakeSessionSearchCriteriaChecksHandler = handler
+// GetUserFriendPIDs sets the GetUserFriendPIDs handler function
+func (commonMatchmakeExtensionProtocol *CommonMatchmakeExtensionProtocol) GetUserFriendPIDs(handler func(pid uint32) []uint32) {
+	common_globals.GetUserFriendPIDsHandler = handler
 }
 
 func initDefault(c *CommonMatchmakeExtensionProtocol) {

--- a/matchmake-extension/update_application_buffer.go
+++ b/matchmake-extension/update_application_buffer.go
@@ -8,7 +8,7 @@ import (
 
 func updateApplicationBuffer(err error, client *nex.Client, callID uint32, gid uint32, applicationBuffer []byte) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/matchmake-extension/update_progress_score.go
+++ b/matchmake-extension/update_progress_score.go
@@ -8,7 +8,7 @@ import (
 
 func updateProgressScore(err error, client *nex.Client, callID uint32, gid uint32, progressScore uint8) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/matchmaking-ext/end_participation.go
+++ b/matchmaking-ext/end_participation.go
@@ -11,7 +11,7 @@ import (
 
 func endParticipation(err error, client *nex.Client, callID uint32, idGathering uint32, strMessage string) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -97,7 +97,7 @@ func endParticipation(err error, client *nex.Client, callID uint32, idGathering 
 
 	targetClient := server.FindClientFromPID(uint32(ownerPID))
 	if targetClient == nil {
-		logger.Warning("Owner client not found")
+		common_globals.Logger.Warning("Owner client not found")
 		return 0
 	}
 

--- a/matchmaking-ext/protocol.go
+++ b/matchmaking-ext/protocol.go
@@ -3,11 +3,9 @@ package match_making_ext
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	match_making_ext "github.com/PretendoNetwork/nex-protocols-go/match-making-ext"
-	"github.com/PretendoNetwork/plogger-go"
 )
 
 var commonMatchMakingExtProtocol *CommonMatchMakingExtProtocol
-var logger = plogger.NewLogger()
 
 type CommonMatchMakingExtProtocol struct {
 	*match_making_ext.Protocol

--- a/matchmaking/find_by_single_id.go
+++ b/matchmaking/find_by_single_id.go
@@ -8,7 +8,7 @@ import (
 
 func findBySingleID(err error, client *nex.Client, callID uint32, id uint32) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/matchmaking/get_session_urls.go
+++ b/matchmaking/get_session_urls.go
@@ -8,7 +8,7 @@ import (
 
 func getSessionURLs(err error, client *nex.Client, callID uint32, gid uint32) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -21,10 +21,10 @@ func getSessionURLs(err error, client *nex.Client, callID uint32, gid uint32) ui
 	hostPID := session.GameMatchmakeSession.Gathering.HostPID
 	host := server.FindClientFromPID(hostPID)
 	if host == nil {
-		logger.Warning("Host client not found, trying with owner client") // This popped up once during testing. Leaving it noted here in case it becomes a problem.
+		common_globals.Logger.Warning("Host client not found, trying with owner client") // This popped up once during testing. Leaving it noted here in case it becomes a problem.
 		host = server.FindClientFromPID(session.GameMatchmakeSession.Gathering.OwnerPID)
 		if host == nil {
-			logger.Error("Owner client not found") // This popped up once during testing. Leaving it noted here in case it becomes a problem.
+			common_globals.Logger.Error("Owner client not found") // This popped up once during testing. Leaving it noted here in case it becomes a problem.
 			return nex.Errors.Core.Exception
 		}
 	}

--- a/matchmaking/protocol.go
+++ b/matchmaking/protocol.go
@@ -7,11 +7,9 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 	_ "github.com/PretendoNetwork/nex-protocols-go"
 	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
-	"github.com/PretendoNetwork/plogger-go"
 )
 
 var commonMatchMakingProtocol *CommonMatchMakingProtocol
-var logger = plogger.NewLogger()
 
 type CommonMatchMakingProtocol struct {
 	*match_making.Protocol

--- a/matchmaking/unregister_gathering.go
+++ b/matchmaking/unregister_gathering.go
@@ -10,7 +10,7 @@ import (
 
 func unregisterGathering(err error, client *nex.Client, callID uint32, idGathering uint32) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -97,7 +97,7 @@ func unregisterGathering(err error, client *nex.Client, callID uint32, idGatheri
 
 			server.Send(messagePacket)
 		} else {
-			logger.Warning("Client not found")
+			common_globals.Logger.Warning("Client not found")
 		}
 	}
 

--- a/matchmaking/update_session_host.go
+++ b/matchmaking/update_session_host.go
@@ -10,7 +10,7 @@ import (
 
 func updateSessionHost(err error, client *nex.Client, callID uint32, gid uint32, isMigrateOwner bool) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -107,7 +107,7 @@ func updateSessionHost(err error, client *nex.Client, callID uint32, gid uint32,
 
 			server.Send(messagePacket)
 		} else {
-			logger.Warning("Client not found")
+			common_globals.Logger.Warning("Client not found")
 		}
 	}
 

--- a/matchmaking/update_session_host_v1.go
+++ b/matchmaking/update_session_host_v1.go
@@ -8,7 +8,7 @@ import (
 
 func updateSessionHostV1(err error, client *nex.Client, callID uint32, gid uint32) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/matchmaking/update_session_url.go
+++ b/matchmaking/update_session_url.go
@@ -8,7 +8,7 @@ import (
 
 func updateSessionURL(err error, client *nex.Client, callID uint32, idGathering uint32, strURL string) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/nat-traversal/get_relay_signature_key.go
+++ b/nat-traversal/get_relay_signature_key.go
@@ -3,11 +3,13 @@ package nattraversal
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	nat_traversal "github.com/PretendoNetwork/nex-protocols-go/nat-traversal"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func getRelaySignatureKey(err error, client *nex.Client, callID uint32) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/nat-traversal/protocol.go
+++ b/nat-traversal/protocol.go
@@ -3,11 +3,9 @@ package nattraversal
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	nat_traversal "github.com/PretendoNetwork/nex-protocols-go/nat-traversal"
-	"github.com/PretendoNetwork/plogger-go"
 )
 
 var commonNATTraversalProtocol *CommonNATTraversalProtocol
-var logger = plogger.NewLogger()
 
 type CommonNATTraversalProtocol struct {
 	*nat_traversal.Protocol

--- a/nat-traversal/report_nat_properties.go
+++ b/nat-traversal/report_nat_properties.go
@@ -3,11 +3,13 @@ package nattraversal
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	nat_traversal "github.com/PretendoNetwork/nex-protocols-go/nat-traversal"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func reportNATProperties(err error, client *nex.Client, callID uint32, natm uint32, natf uint32, rtt uint32) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/nat-traversal/report_nat_traversal_result.go
+++ b/nat-traversal/report_nat_traversal_result.go
@@ -3,11 +3,13 @@ package nattraversal
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	nat_traversal "github.com/PretendoNetwork/nex-protocols-go/nat-traversal"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func reportNATTraversalResult(err error, client *nex.Client, callID uint32, cid uint32, result bool, rtt uint32) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/nat-traversal/report_nat_traversal_result_detail.go
+++ b/nat-traversal/report_nat_traversal_result_detail.go
@@ -3,11 +3,13 @@ package nattraversal
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	nat_traversal "github.com/PretendoNetwork/nex-protocols-go/nat-traversal"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func reportNATTraversalResultDetail(err error, client *nex.Client, callID uint32, cid uint32, result bool, detail int32, rtt uint32) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/nat-traversal/request_probe_initiation_ext.go
+++ b/nat-traversal/request_probe_initiation_ext.go
@@ -3,11 +3,13 @@ package nattraversal
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	nat_traversal "github.com/PretendoNetwork/nex-protocols-go/nat-traversal"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func requestProbeInitiationExt(err error, client *nex.Client, callID uint32, targetList []string, stationToProbe string) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
@@ -73,7 +75,7 @@ func requestProbeInitiationExt(err error, client *nex.Client, callID uint32, tar
 
 			server.Send(messagePacket)
 		} else {
-			logger.Warning("Client not found")
+			common_globals.Logger.Warning("Client not found")
 		}
 	}
 

--- a/ranking/get_cached_top_x_ranking.go
+++ b/ranking/get_cached_top_x_ranking.go
@@ -1,29 +1,31 @@
 package ranking
 
 import (
+	"time"
+
 	"github.com/PretendoNetwork/nex-go"
 	ranking "github.com/PretendoNetwork/nex-protocols-go/ranking"
 	ranking_types "github.com/PretendoNetwork/nex-protocols-go/ranking/types"
 
-	"time"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func getCachedTopXRanking(err error, client *nex.Client, callID uint32, category uint32, orderParam *ranking_types.RankingOrderParam) uint32 {
 	if commonRankingProtocol.getRankingsAndCountByCategoryAndRankingOrderParamHandler == nil {
-		logger.Warning("Ranking::GetCachedTopXRanking missing GetRankingsAndCountByCategoryAndRankingOrderParamHandler!")
+		common_globals.Logger.Warning("Ranking::GetCachedTopXRanking missing GetRankingsAndCountByCategoryAndRankingOrderParamHandler!")
 		return nex.Errors.Core.NotImplemented
 	}
 
 	server := client.Server()
 
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Ranking.InvalidArgument
 	}
 
 	rankDataList, totalCount, err := commonRankingProtocol.getRankingsAndCountByCategoryAndRankingOrderParamHandler(category, orderParam)
 	if err != nil {
-		logger.Critical(err.Error())
+		common_globals.Logger.Critical(err.Error())
 		return nex.Errors.Ranking.Unknown
 	}
 

--- a/ranking/get_cached_top_x_rankings.go
+++ b/ranking/get_cached_top_x_rankings.go
@@ -1,23 +1,25 @@
 package ranking
 
 import (
+	"time"
+
 	"github.com/PretendoNetwork/nex-go"
 	ranking "github.com/PretendoNetwork/nex-protocols-go/ranking"
 	ranking_types "github.com/PretendoNetwork/nex-protocols-go/ranking/types"
 
-	"time"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func getCachedTopXRankings(err error, client *nex.Client, callID uint32, categories []uint32, orderParams []*ranking_types.RankingOrderParam) uint32 {
 	if commonRankingProtocol.getRankingsAndCountByCategoryAndRankingOrderParamHandler == nil {
-		logger.Warning("Ranking::GetCachedTopXRankings missing GetRankingsAndCountByCategoryAndRankingOrderParamHandler!")
+		common_globals.Logger.Warning("Ranking::GetCachedTopXRankings missing GetRankingsAndCountByCategoryAndRankingOrderParamHandler!")
 		return nex.Errors.Core.NotImplemented
 	}
 	
 	server := client.Server()
 
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Ranking.InvalidArgument
 	}
 	
@@ -25,7 +27,7 @@ func getCachedTopXRankings(err error, client *nex.Client, callID uint32, categor
 	for i := 0; i < len(categories); i++ {
 		rankDataList, totalCount, err := commonRankingProtocol.getRankingsAndCountByCategoryAndRankingOrderParamHandler(categories[i], orderParams[i])
 		if err != nil {
-			logger.Critical(err.Error())
+			common_globals.Logger.Critical(err.Error())
 			return nex.Errors.Ranking.Unknown
 		}
 

--- a/ranking/get_common_data.go
+++ b/ranking/get_common_data.go
@@ -3,18 +3,20 @@ package ranking
 import (
 	"github.com/PretendoNetwork/nex-go"
 	ranking "github.com/PretendoNetwork/nex-protocols-go/ranking"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func getCommonData(err error, client *nex.Client, callID uint32, uniqueID uint64) uint32 {
 	if commonRankingProtocol.getCommonDataHandler == nil {
-		logger.Warning("Ranking::GetCommonData missing GetCommonDataHandler!")
+		common_globals.Logger.Warning("Ranking::GetCommonData missing GetCommonDataHandler!")
 		return nex.Errors.Core.NotImplemented
 	}
 
 	server := client.Server()
 
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Ranking.InvalidArgument
 	}
 

--- a/ranking/get_ranking.go
+++ b/ranking/get_ranking.go
@@ -4,24 +4,26 @@ import (
 	"github.com/PretendoNetwork/nex-go"
 	ranking "github.com/PretendoNetwork/nex-protocols-go/ranking"
 	ranking_types "github.com/PretendoNetwork/nex-protocols-go/ranking/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func getRanking(err error, client *nex.Client, callID uint32, rankingMode uint8, category uint32, orderParam *ranking_types.RankingOrderParam, uniqueID uint64, principalID uint32) uint32 {
 	if commonRankingProtocol.getRankingsAndCountByCategoryAndRankingOrderParamHandler == nil {
-		logger.Warning("Ranking::GetRanking missing GetRankingsAndCountByCategoryAndRankingOrderParamHandler!")
+		common_globals.Logger.Warning("Ranking::GetRanking missing GetRankingsAndCountByCategoryAndRankingOrderParamHandler!")
 		return nex.Errors.Core.NotImplemented
 	}
 	
 	server := client.Server()
 
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Ranking.InvalidArgument
 	}
 
 	rankDataList, totalCount, err := commonRankingProtocol.getRankingsAndCountByCategoryAndRankingOrderParamHandler(category, orderParam)
 	if err != nil {
-		logger.Critical(err.Error())
+		common_globals.Logger.Critical(err.Error())
 		return nex.Errors.Ranking.Unknown
 	}
 

--- a/ranking/protocol.go
+++ b/ranking/protocol.go
@@ -7,11 +7,11 @@ import (
 	ranking "github.com/PretendoNetwork/nex-protocols-go/ranking"
 	ranking_mario_kart_8 "github.com/PretendoNetwork/nex-protocols-go/ranking/mario-kart-8"
 	ranking_types "github.com/PretendoNetwork/nex-protocols-go/ranking/types"
-	"github.com/PretendoNetwork/plogger-go"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 var commonRankingProtocol *CommonRankingProtocol
-var logger = plogger.NewLogger()
 
 type CommonRankingProtocol struct {
 	server             *nex.Server
@@ -73,14 +73,14 @@ func NewCommonRankingProtocol(server *nex.Server) *CommonRankingProtocol {
 	patch := server.MatchMakingProtocolVersion().GameSpecificPatch
 
 	if strings.EqualFold(patch, "AMKJ") {
-		logger.Info("Using Mario Kart 8 Ranking protocol")
+		common_globals.Logger.Info("Using Mario Kart 8 Ranking protocol")
 		initMarioKart8(commonRankingProtocol)
 	} else {
 		if patch != "" {
-			logger.Infof("Ranking version patch %q not recognized", patch)
+			common_globals.Logger.Infof("Ranking version patch %q not recognized", patch)
 		}
 
-		logger.Info("Using default Ranking protocol")
+		common_globals.Logger.Info("Using default Ranking protocol")
 		initDefault(commonRankingProtocol)
 	}
 

--- a/ranking/upload_common_data.go
+++ b/ranking/upload_common_data.go
@@ -3,24 +3,26 @@ package ranking
 import (
 	"github.com/PretendoNetwork/nex-go"
 	ranking "github.com/PretendoNetwork/nex-protocols-go/ranking"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func uploadCommonData(err error, client *nex.Client, callID uint32, commonData []byte, uniqueID uint64) uint32 {
 	if commonRankingProtocol.uploadCommonDataHandler == nil {
-		logger.Warning("Ranking::UploadCommonData missing UploadCommonDataHandler!")
+		common_globals.Logger.Warning("Ranking::UploadCommonData missing UploadCommonDataHandler!")
 		return nex.Errors.Core.NotImplemented
 	}
 
 	server := client.Server()
 
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Ranking.InvalidArgument
 	}
 
 	err = commonRankingProtocol.uploadCommonDataHandler(client.PID(), uniqueID, commonData)
 	if err != nil {
-		logger.Critical(err.Error())
+		common_globals.Logger.Critical(err.Error())
 		return nex.Errors.Ranking.Unknown
 	}
 	

--- a/ranking/upload_score.go
+++ b/ranking/upload_score.go
@@ -4,24 +4,26 @@ import (
 	"github.com/PretendoNetwork/nex-go"
 	ranking "github.com/PretendoNetwork/nex-protocols-go/ranking"
 	ranking_types "github.com/PretendoNetwork/nex-protocols-go/ranking/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func uploadScore(err error, client *nex.Client, callID uint32, scoreData *ranking_types.RankingScoreData, uniqueID uint64) uint32 {
 	if commonRankingProtocol.insertRankingByPIDAndRankingScoreDataHandler == nil {
-		logger.Warning("Ranking::UploadScore missing InsertRankingByPIDAndRankingScoreDataHandler!")
+		common_globals.Logger.Warning("Ranking::UploadScore missing InsertRankingByPIDAndRankingScoreDataHandler!")
 		return nex.Errors.Core.NotImplemented
 	}
 
 	server := client.Server()
 
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Ranking.InvalidArgument
 	}
 
 	err = commonRankingProtocol.insertRankingByPIDAndRankingScoreDataHandler(client.PID(), scoreData, uniqueID)
 	if err != nil {
-		logger.Critical(err.Error())
+		common_globals.Logger.Critical(err.Error())
 		return nex.Errors.Ranking.Unknown
 	}
 	

--- a/secure-connection/connect.go
+++ b/secure-connection/connect.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/PretendoNetwork/nex-go"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func connect(packet nex.PacketInterface) {
@@ -14,14 +16,14 @@ func connect(packet nex.PacketInterface) {
 
 	ticketData, err := stream.ReadBuffer()
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		server.TimeoutKick(packet.Sender())
 		return
 	}
 
 	requestData, err := stream.ReadBuffer()
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		server.TimeoutKick(packet.Sender())
 		return
 	}
@@ -31,7 +33,7 @@ func connect(packet nex.PacketInterface) {
 	ticket := nex.NewKerberosTicketInternalData()
 	err = ticket.Decrypt(nex.NewStreamIn(ticketData, server), serverKey)
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		server.TimeoutKick(packet.Sender())
 		return
 	}
@@ -41,7 +43,7 @@ func connect(packet nex.PacketInterface) {
 
 	timeLimit := ticketTime.Add(time.Minute * 2)
 	if serverTime.After(timeLimit) {
-		logger.Error("Kerberos ticket expired")
+		common_globals.Logger.Error("Kerberos ticket expired")
 		server.TimeoutKick(packet.Sender())
 		return
 	}
@@ -49,7 +51,7 @@ func connect(packet nex.PacketInterface) {
 	sessionKey := ticket.SessionKey()
 	kerberos, err := nex.NewKerberosEncryption(sessionKey)
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		server.TimeoutKick(packet.Sender())
 		return
 	}
@@ -59,21 +61,21 @@ func connect(packet nex.PacketInterface) {
 
 	userPID, err := checkDataStream.ReadUInt32LE()
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		server.TimeoutKick(packet.Sender())
 		return
 	}
 
 	_, err = checkDataStream.ReadUInt32LE() // CID of secure server station url
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		server.TimeoutKick(packet.Sender())
 		return
 	}
 
 	responseCheck, err := checkDataStream.ReadUInt32LE()
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		server.TimeoutKick(packet.Sender())
 		return
 	}
@@ -88,7 +90,7 @@ func connect(packet nex.PacketInterface) {
 
 	err = packet.Sender().UpdateRC4Key(sessionKey)
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		server.TimeoutKick(packet.Sender())
 		return
 	}

--- a/secure-connection/protocol.go
+++ b/secure-connection/protocol.go
@@ -3,11 +3,9 @@ package secureconnection
 import (
 	"github.com/PretendoNetwork/nex-go"
 	secure_connection "github.com/PretendoNetwork/nex-protocols-go/secure-connection"
-	"github.com/PretendoNetwork/plogger-go"
 )
 
 var commonSecureConnectionProtocol *CommonSecureConnectionProtocol
-var logger = plogger.NewLogger()
 
 type CommonSecureConnectionProtocol struct {
 	*secure_connection.Protocol

--- a/secure-connection/register.go
+++ b/secure-connection/register.go
@@ -3,11 +3,13 @@ package secureconnection
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	secure_connection "github.com/PretendoNetwork/nex-protocols-go/secure-connection"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func register(err error, client *nex.Client, callID uint32, stationUrls []*nex.StationURL) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/secure-connection/replace_url.go
+++ b/secure-connection/replace_url.go
@@ -3,11 +3,13 @@ package secureconnection
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	secure_connection "github.com/PretendoNetwork/nex-protocols-go/secure-connection"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func replaceURL(err error, client *nex.Client, callID uint32, oldStation *nex.StationURL, newStation *nex.StationURL) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/secure-connection/send_report.go
+++ b/secure-connection/send_report.go
@@ -3,22 +3,24 @@ package secureconnection
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	secure_connection "github.com/PretendoNetwork/nex-protocols-go/secure-connection"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func sendReport(err error, client *nex.Client, callID uint32, reportID uint32, reportData []byte) uint32 {
 	if commonSecureConnectionProtocol.createReportDBRecordHandler == nil {
-		logger.Warning("SecureConnection::SendReport missing CreateReportDBRecord!")
+		common_globals.Logger.Warning("SecureConnection::SendReport missing CreateReportDBRecord!")
 		return nex.Errors.Core.NotImplemented
 	}
 
 	if err != nil {
-		logger.Critical(err.Error())
+		common_globals.Logger.Critical(err.Error())
 		return nex.Errors.Core.Unknown
 	}
 
 	err = commonSecureConnectionProtocol.createReportDBRecordHandler(client.PID(), reportID, reportData)
 	if err != nil {
-		logger.Critical(err.Error())
+		common_globals.Logger.Critical(err.Error())
 		return nex.Errors.Core.Unknown
 	}
 

--- a/ticket-granting/generate_ticket.go
+++ b/ticket-granting/generate_ticket.go
@@ -4,12 +4,14 @@ import (
 	"crypto/rand"
 
 	"github.com/PretendoNetwork/nex-go"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func generateTicket(userPID uint32, targetPID uint32) ([]byte, uint32) {
 	passwordFromPIDHandler := commonTicketGrantingProtocol.server.PasswordFromPIDFunction()
 	if passwordFromPIDHandler == nil {
-		logger.Warning("Missing passwordFromPIDHandler!")
+		common_globals.Logger.Warning("Missing passwordFromPIDHandler!")
 		return []byte{}, nex.Errors.Core.Unknown
 	}
 
@@ -49,7 +51,7 @@ func generateTicket(userPID uint32, targetPID uint32) ([]byte, uint32) {
 	sessionKey := make([]byte, commonTicketGrantingProtocol.server.KerberosKeySize())
 	_, err := rand.Read(sessionKey)
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return []byte{}, nex.Errors.Authentication.Unknown
 	}
 
@@ -62,7 +64,7 @@ func generateTicket(userPID uint32, targetPID uint32) ([]byte, uint32) {
 
 	encryptedTicketInternalData, err := ticketInternalData.Encrypt(targetKey, nex.NewStreamOut(commonTicketGrantingProtocol.server))
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return []byte{}, nex.Errors.Authentication.Unknown
 	}
 
@@ -73,7 +75,7 @@ func generateTicket(userPID uint32, targetPID uint32) ([]byte, uint32) {
 
 	encryptedTicket, err := ticket.Encrypt(userKey, nex.NewStreamOut(commonTicketGrantingProtocol.server))
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return []byte{}, nex.Errors.Authentication.Unknown
 	}
 

--- a/ticket-granting/login.go
+++ b/ticket-granting/login.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/PretendoNetwork/nex-go"
 	ticket_granting "github.com/PretendoNetwork/nex-protocols-go/ticket-granting"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func login(err error, client *nex.Client, callID uint32, username string) uint32 {
@@ -14,7 +16,7 @@ func login(err error, client *nex.Client, callID uint32, username string) uint32
 	}
 
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/ticket-granting/login_ex.go
+++ b/ticket-granting/login_ex.go
@@ -6,11 +6,13 @@ import (
 
 	nex "github.com/PretendoNetwork/nex-go"
 	ticket_granting "github.com/PretendoNetwork/nex-protocols-go/ticket-granting"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func loginEx(err error, client *nex.Client, callID uint32, username string, oExtraData *nex.DataHolder) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/ticket-granting/protocol.go
+++ b/ticket-granting/protocol.go
@@ -4,11 +4,11 @@ import (
 	"github.com/PretendoNetwork/nex-go"
 	_ "github.com/PretendoNetwork/nex-protocols-go"
 	ticket_granting "github.com/PretendoNetwork/nex-protocols-go/ticket-granting"
-	"github.com/PretendoNetwork/plogger-go"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 var commonTicketGrantingProtocol *CommonTicketGrantingProtocol
-var logger = plogger.NewLogger()
 
 type CommonTicketGrantingProtocol struct {
 	*ticket_granting.Protocol
@@ -31,7 +31,7 @@ func (commonTicketGrantingProtocol *CommonTicketGrantingProtocol) DisableInsecur
 }
 
 func (commonTicketGrantingProtocol *CommonTicketGrantingProtocol) EnableInsecureLogin() {
-	logger.Warning("INSECURE LOGIN HAS BEEN ENABLED. THIS ALLOWS THE USE OF CUSTOM CLIENTS TO BYPASS THE ACCOUNT SERVER AND CONNECT DIRECTLY TO THIS GAME SERVER, EVADING BANS! USE WITH CAUTION!")
+	common_globals.Logger.Warning("INSECURE LOGIN HAS BEEN ENABLED. THIS ALLOWS THE USE OF CUSTOM CLIENTS TO BYPASS THE ACCOUNT SERVER AND CONNECT DIRECTLY TO THIS GAME SERVER, EVADING BANS! USE WITH CAUTION!")
 	commonTicketGrantingProtocol.allowInsecureLoginMethod = true
 }
 

--- a/ticket-granting/request_ticket.go
+++ b/ticket-granting/request_ticket.go
@@ -3,11 +3,13 @@ package ticket_granting
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	ticket_granting "github.com/PretendoNetwork/nex-protocols-go/ticket-granting"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func requestTicket(err error, client *nex.Client, callID uint32, userPID uint32, targetPID uint32) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/utility/acquire_nex_unique_id.go
+++ b/utility/acquire_nex_unique_id.go
@@ -3,11 +3,13 @@ package utility
 import (
 	nex "github.com/PretendoNetwork/nex-go"
 	utility "github.com/PretendoNetwork/nex-protocols-go/utility"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
 func acquireNexUniqueID(err error, client *nex.Client, callID uint32) uint32 {
 	if err != nil {
-		logger.Error(err.Error())
+		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 

--- a/utility/protocol.go
+++ b/utility/protocol.go
@@ -5,13 +5,10 @@ import (
 	"time"
 
 	nex "github.com/PretendoNetwork/nex-go"
-	_ "github.com/PretendoNetwork/nex-protocols-go"
 	utility "github.com/PretendoNetwork/nex-protocols-go/utility"
-	"github.com/PretendoNetwork/plogger-go"
 )
 
 var commonUtilityProtocol *CommonUtilityProtocol
-var logger = plogger.NewLogger()
 
 type CommonUtilityProtocol struct {
 	*utility.Protocol


### PR DESCRIPTION
The `MatchmakeSessionSearchCriteria` is intended to be compared with the original session to find valid sessions. Thus, we can remove the `SearchCriteria` field that we are storing internally and instead compare values with the session.

With this, we implement comparing attributes by default, unless game-specific checks are defined, in which case the attribute search gets overriden. This allows overriding region-locked matchmaking.

This also allows removing session creation that requires search criteria `CreateSessionBySearchCriteria` and instead move everything to `CreateSessionByMatchmakeSession`.

We can also remove the cleanup of search criteria, since it's redundant considering we allow game-specific checks.

Friends-only matches are also now supported, and requires setting the `GetUserFriendPIDs` handler on `MatchmakeExtension`.

This improves accuracy finding sessions and is how Rambo's MK8 server is implemented.

Aside from that, I'm considering moving the logger to the globals, so that we can log from `globals`.

Tested successfully with:
- Mario Kart 7
- Steel Diver: Sub Wars
- IRONFALL Invasion