### PR TITLE
Add missing boolean response to UnregisterGathering

### DIFF
--- a/matchmaking/unregister_gathering.go
+++ b/matchmaking/unregister_gathering.go
@@ -30,8 +30,13 @@ func unregisterGathering(err error, client *nex.Client, callID uint32, idGatheri
 
 	delete(common_globals.Sessions, idGathering)
 
+	rmcResponseStream := nex.NewStreamOut(server)
+	rmcResponseStream.WriteBool(true) // %retval%
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
 	rmcResponse := nex.NewRMCResponse(match_making.ProtocolID, callID)
-	rmcResponse.SetSuccess(match_making.MethodUnregisterGathering, nil)
+	rmcResponse.SetSuccess(match_making.MethodUnregisterGathering, rmcResponseBody)
 
 	rmcResponseBytes := rmcResponse.Bytes()
 


### PR DESCRIPTION
According to documentation, MatchMaking(21)::UnregisterGathing(2) expects a boolean in the response. This code always fills in true.

Some titles, such as Pokkén Tournament, appear to expect this value.