### PR TITLE
Swap to passing the packet to methods instead of the client

### DIFF
--- a/datastore/change_meta.go
+++ b/datastore/change_meta.go
@@ -7,7 +7,7 @@ import (
 	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
 )
 
-func changeMeta(err error, client *nex.Client, callID uint32, param *datastore_types.DataStoreChangeMetaParam) uint32 {
+func changeMeta(err error, packet nex.PacketInterface, callID uint32, param *datastore_types.DataStoreChangeMetaParam) uint32 {
 	if commonDataStoreProtocol.getObjectInfoByDataIDHandler == nil {
 		common_globals.Logger.Warning("GetObjectInfoByDataID not defined")
 		return nex.Errors.Core.NotImplemented
@@ -32,6 +32,8 @@ func changeMeta(err error, client *nex.Client, callID uint32, param *datastore_t
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.DataStore.Unknown
 	}
+
+	client := packet.Sender()
 
 	metaInfo, errCode := commonDataStoreProtocol.getObjectInfoByDataIDHandler(param.DataID)
 	if errCode != 0 {
@@ -80,8 +82,8 @@ func changeMeta(err error, client *nex.Client, callID uint32, param *datastore_t
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/datastore/complete_post_object.go
+++ b/datastore/complete_post_object.go
@@ -9,7 +9,7 @@ import (
 	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
 )
 
-func completePostObject(err error, client *nex.Client, callID uint32, param *datastore_types.DataStoreCompletePostParam) uint32 {
+func completePostObject(err error, packet nex.PacketInterface, callID uint32, param *datastore_types.DataStoreCompletePostParam) uint32 {
 	if commonDataStoreProtocol.minIOClient == nil {
 		common_globals.Logger.Warning("MinIOClient not defined")
 		return nex.Errors.Core.NotImplemented
@@ -44,6 +44,8 @@ func completePostObject(err error, client *nex.Client, callID uint32, param *dat
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.DataStore.Unknown
 	}
+
+	client := packet.Sender()
 
 	// * If GetObjectInfoByDataID returns data then that means
 	// * the object has already been marked as uploaded. So do
@@ -110,8 +112,8 @@ func completePostObject(err error, client *nex.Client, callID uint32, param *dat
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/datastore/complete_post_objects.go
+++ b/datastore/complete_post_objects.go
@@ -8,7 +8,7 @@ import (
 	datastore "github.com/PretendoNetwork/nex-protocols-go/datastore"
 )
 
-func completePostObjects(err error, client *nex.Client, callID uint32, dataIDs []uint64) uint32 {
+func completePostObjects(err error, packet nex.PacketInterface, callID uint32, dataIDs []uint64) uint32 {
 	if commonDataStoreProtocol.minIOClient == nil {
 		common_globals.Logger.Warning("MinIOClient not defined")
 		return nex.Errors.Core.NotImplemented
@@ -28,6 +28,8 @@ func completePostObjects(err error, client *nex.Client, callID uint32, dataIDs [
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.DataStore.Unknown
 	}
+
+	client := packet.Sender()
 
 	for _, dataID := range dataIDs {
 		bucket := commonDataStoreProtocol.s3Bucket
@@ -71,8 +73,8 @@ func completePostObjects(err error, client *nex.Client, callID uint32, dataIDs [
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/datastore/delete_object.go
+++ b/datastore/delete_object.go
@@ -7,7 +7,7 @@ import (
 	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
 )
 
-func deleteObject(err error, client *nex.Client, callID uint32, param *datastore_types.DataStoreDeleteParam) uint32 {
+func deleteObject(err error, packet nex.PacketInterface, callID uint32, param *datastore_types.DataStoreDeleteParam) uint32 {
 	if commonDataStoreProtocol.getObjectInfoByDataIDHandler == nil {
 		common_globals.Logger.Warning("GetObjectInfoByDataID not defined")
 		return nex.Errors.Core.NotImplemented
@@ -22,6 +22,8 @@ func deleteObject(err error, client *nex.Client, callID uint32, param *datastore
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.DataStore.Unknown
 	}
+
+	client := packet.Sender()
 
 	metaInfo, errCode := commonDataStoreProtocol.getObjectInfoByDataIDHandler(param.DataID)
 	if errCode != 0 {
@@ -53,8 +55,8 @@ func deleteObject(err error, client *nex.Client, callID uint32, param *datastore
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/datastore/get_meta.go
+++ b/datastore/get_meta.go
@@ -7,7 +7,7 @@ import (
 	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
 )
 
-func getMeta(err error, client *nex.Client, callID uint32, param *datastore_types.DataStoreGetMetaParam) uint32 {
+func getMeta(err error, packet nex.PacketInterface, callID uint32, param *datastore_types.DataStoreGetMetaParam) uint32 {
 	if commonDataStoreProtocol.getObjectInfoByPersistenceTargetWithPasswordHandler == nil {
 		common_globals.Logger.Warning("GetObjectInfoByPersistenceTargetWithPassword not defined")
 		return nex.Errors.Core.NotImplemented
@@ -22,6 +22,8 @@ func getMeta(err error, client *nex.Client, callID uint32, param *datastore_type
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.DataStore.Unknown
 	}
+
+	client := packet.Sender()
 
 	var pMetaInfo *datastore_types.DataStoreMetaInfo
 	var errCode uint32
@@ -64,8 +66,8 @@ func getMeta(err error, client *nex.Client, callID uint32, param *datastore_type
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/datastore/get_metas.go
+++ b/datastore/get_metas.go
@@ -7,7 +7,7 @@ import (
 	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
 )
 
-func getMetas(err error, client *nex.Client, callID uint32, dataIDs []uint64, param *datastore_types.DataStoreGetMetaParam) uint32 {
+func getMetas(err error, packet nex.PacketInterface, callID uint32, dataIDs []uint64, param *datastore_types.DataStoreGetMetaParam) uint32 {
 	if commonDataStoreProtocol.getObjectInfoByDataIDHandler == nil {
 		common_globals.Logger.Warning("GetObjectInfoByDataID not defined")
 		return nex.Errors.Core.NotImplemented
@@ -17,6 +17,8 @@ func getMetas(err error, client *nex.Client, callID uint32, dataIDs []uint64, pa
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.DataStore.Unknown
 	}
+
+	client := packet.Sender()
 
 	// TODO - Verify if param.PersistenceTarget is respected? It wouldn't make sense here but who knows
 
@@ -73,8 +75,8 @@ func getMetas(err error, client *nex.Client, callID uint32, dataIDs []uint64, pa
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/datastore/get_metas_multiple_param.go
+++ b/datastore/get_metas_multiple_param.go
@@ -7,7 +7,7 @@ import (
 	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
 )
 
-func getMetasMultipleParam(err error, client *nex.Client, callID uint32, params []*datastore_types.DataStoreGetMetaParam) uint32 {
+func getMetasMultipleParam(err error, packet nex.PacketInterface, callID uint32, params []*datastore_types.DataStoreGetMetaParam) uint32 {
 	if commonDataStoreProtocol.getObjectInfoByPersistenceTargetWithPasswordHandler == nil {
 		common_globals.Logger.Warning("GetObjectInfoByPersistenceTargetWithPassword not defined")
 		return nex.Errors.Core.NotImplemented
@@ -22,6 +22,8 @@ func getMetasMultipleParam(err error, client *nex.Client, callID uint32, params 
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.DataStore.Unknown
 	}
+
+	client := packet.Sender()
 
 	pMetaInfo := make([]*datastore_types.DataStoreMetaInfo, 0, len(params))
 	pResults := make([]*nex.Result, 0, len(params))
@@ -79,8 +81,8 @@ func getMetasMultipleParam(err error, client *nex.Client, callID uint32, params 
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/datastore/post_meta_binary.go
+++ b/datastore/post_meta_binary.go
@@ -7,7 +7,7 @@ import (
 	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
 )
 
-func postMetaBinary(err error, client *nex.Client, callID uint32, param *datastore_types.DataStorePreparePostParam) uint32 {
+func postMetaBinary(err error, packet nex.PacketInterface, callID uint32, param *datastore_types.DataStorePreparePostParam) uint32 {
 	// * This method looks to function identically to DataStore::PreparePostObject,
 	// * except the only difference being it doesn't return an S3 upload URL. This
 	// * needs to be verified though, as there are other methods in the family such
@@ -29,6 +29,8 @@ func postMetaBinary(err error, client *nex.Client, callID uint32, param *datasto
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.DataStore.Unknown
 	}
+
+	client := packet.Sender()
 
 	// TODO - Need to verify what param.PersistenceInitParam.DeleteLastObject really means. It's often set to true even when it wouldn't make sense
 	dataID, errCode := commonDataStoreProtocol.initializeObjectByPreparePostParamHandler(client.PID(), param)
@@ -67,8 +69,8 @@ func postMetaBinary(err error, client *nex.Client, callID uint32, param *datasto
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/datastore/prepare_get_object.go
+++ b/datastore/prepare_get_object.go
@@ -10,7 +10,7 @@ import (
 	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
 )
 
-func prepareGetObject(err error, client *nex.Client, callID uint32, param *datastore_types.DataStorePrepareGetParam) uint32 {
+func prepareGetObject(err error, packet nex.PacketInterface, callID uint32, param *datastore_types.DataStorePrepareGetParam) uint32 {
 	if commonDataStoreProtocol.getObjectInfoByDataIDHandler == nil {
 		common_globals.Logger.Warning("GetObjectInfoByDataID not defined")
 		return nex.Errors.Core.NotImplemented
@@ -25,6 +25,8 @@ func prepareGetObject(err error, client *nex.Client, callID uint32, param *datas
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.Unknown
 	}
+
+	client := packet.Sender()
 
 	bucket := commonDataStoreProtocol.s3Bucket
 	key := fmt.Sprintf("%s/%d.bin", commonDataStoreProtocol.s3DataKeyBase, param.DataID)
@@ -79,8 +81,8 @@ func prepareGetObject(err error, client *nex.Client, callID uint32, param *datas
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/datastore/prepare_post_object.go
+++ b/datastore/prepare_post_object.go
@@ -10,7 +10,7 @@ import (
 	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
 )
 
-func preparePostObject(err error, client *nex.Client, callID uint32, param *datastore_types.DataStorePreparePostParam) uint32 {
+func preparePostObject(err error, packet nex.PacketInterface, callID uint32, param *datastore_types.DataStorePreparePostParam) uint32 {
 	if commonDataStoreProtocol.initializeObjectByPreparePostParamHandler == nil {
 		common_globals.Logger.Warning("InitializeObjectByPreparePostParam not defined")
 		return nex.Errors.Core.NotImplemented
@@ -30,6 +30,8 @@ func preparePostObject(err error, client *nex.Client, callID uint32, param *data
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.DataStore.Unknown
 	}
+
+	client := packet.Sender()
 
 	// TODO - Need to verify what param.PersistenceInitParam.DeleteLastObject really means. It's often set to true even when it wouldn't make sense
 	dataID, errCode := commonDataStoreProtocol.initializeObjectByPreparePostParamHandler(client.PID(), param)
@@ -98,8 +100,8 @@ func preparePostObject(err error, client *nex.Client, callID uint32, param *data
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/datastore/rate_object.go
+++ b/datastore/rate_object.go
@@ -7,7 +7,7 @@ import (
 	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
 )
 
-func rateObject(err error, client *nex.Client, callID uint32, target *datastore_types.DataStoreRatingTarget, param *datastore_types.DataStoreRateObjectParam, fetchRatings bool) uint32 {
+func rateObject(err error, packet nex.PacketInterface, callID uint32, target *datastore_types.DataStoreRatingTarget, param *datastore_types.DataStoreRateObjectParam, fetchRatings bool) uint32 {
 	if commonDataStoreProtocol.getObjectInfoByDataIDWithPasswordHandler == nil {
 		common_globals.Logger.Warning("GetObjectInfoByDataIDWithPassword not defined")
 		return nex.Errors.Core.NotImplemented
@@ -22,6 +22,8 @@ func rateObject(err error, client *nex.Client, callID uint32, target *datastore_
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.DataStore.Unknown
 	}
+
+	client := packet.Sender()
 
 	objectInfo, errCode := commonDataStoreProtocol.getObjectInfoByDataIDWithPasswordHandler(target.DataID, param.AccessPassword)
 	if errCode != 0 {
@@ -67,8 +69,8 @@ func rateObject(err error, client *nex.Client, callID uint32, target *datastore_
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/datastore/rate_objects.go
+++ b/datastore/rate_objects.go
@@ -7,7 +7,7 @@ import (
 	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
 )
 
-func rateObjects(err error, client *nex.Client, callID uint32, targets []*datastore_types.DataStoreRatingTarget, params []*datastore_types.DataStoreRateObjectParam, transactional bool, fetchRatings bool) uint32 {
+func rateObjects(err error, packet nex.PacketInterface, callID uint32, targets []*datastore_types.DataStoreRatingTarget, params []*datastore_types.DataStoreRateObjectParam, transactional bool, fetchRatings bool) uint32 {
 	if commonDataStoreProtocol.getObjectInfoByDataIDWithPasswordHandler == nil {
 		common_globals.Logger.Warning("GetObjectInfoByDataIDWithPassword not defined")
 		return nex.Errors.Core.NotImplemented
@@ -22,6 +22,8 @@ func rateObjects(err error, client *nex.Client, callID uint32, targets []*datast
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.DataStore.Unknown
 	}
+
+	client := packet.Sender()
 
 	pRatings := make([]*datastore_types.DataStoreRatingInfo, 0)
 	pResults := make([]*nex.Result, 0)
@@ -80,8 +82,8 @@ func rateObjects(err error, client *nex.Client, callID uint32, targets []*datast
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/datastore/search_object.go
+++ b/datastore/search_object.go
@@ -7,7 +7,7 @@ import (
 	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
 )
 
-func searchObject(err error, client *nex.Client, callID uint32, param *datastore_types.DataStoreSearchParam) uint32 {
+func searchObject(err error, packet nex.PacketInterface, callID uint32, param *datastore_types.DataStoreSearchParam) uint32 {
 	if commonDataStoreProtocol.getObjectInfosByDataStoreSearchParamHandler == nil {
 		common_globals.Logger.Warning("GetObjectInfosByDataStoreSearchParam not defined")
 		return nex.Errors.Core.NotImplemented
@@ -17,6 +17,8 @@ func searchObject(err error, client *nex.Client, callID uint32, param *datastore
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.DataStore.Unknown
 	}
+
+	client := packet.Sender()
 
 	// * This is likely game-specific. Also developer note:
 	// * Please keep in mind that no results is allowed. errCode
@@ -95,8 +97,8 @@ func searchObject(err error, client *nex.Client, callID uint32, param *datastore
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/globals/matchmaking_utils.go
+++ b/globals/matchmaking_utils.go
@@ -1,11 +1,11 @@
 package common_globals
 
 import (
+	"crypto/rand"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
-	"crypto/rand"
 
 	nex "github.com/PretendoNetwork/nex-go"
 	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
@@ -356,7 +356,6 @@ func AddPlayersToSession(session *CommonMatchmakeSession, connectionIDs []uint32
 
 	server := initiatingClient.Server()
 
-	
 	for i := 0; i < len(session.ConnectionIDs); i++ {
 		target := server.FindClientFromConnectionID(session.ConnectionIDs[i])
 		if target == nil {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/PretendoNetwork/nex-go v1.0.41
-	github.com/PretendoNetwork/nex-protocols-go v1.0.57
+	github.com/PretendoNetwork/nex-protocols-go v1.0.58
 	github.com/PretendoNetwork/plogger-go v1.0.4
 	github.com/minio/minio-go/v7 v7.0.63
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/PretendoNetwork/nex-go v1.0.41 h1:TcBb1Bpe2KAB+AXaGX1K9NVQBRtZJIoy4yCvRde2xbI=
 github.com/PretendoNetwork/nex-go v1.0.41/go.mod h1:QwHEa165DeVd0xIuthrgc3j6NWXT8lyPSG6t5kC/Shk=
-github.com/PretendoNetwork/nex-protocols-go v1.0.57 h1:7VosWcDuYbciGgWfgvRd2zDW7uTfcmFzlPbmaPkI7L4=
-github.com/PretendoNetwork/nex-protocols-go v1.0.57/go.mod h1:136762CMIcAsTZDrt4W7gDE4ppiBuc9zN2QFOHESjS8=
+github.com/PretendoNetwork/nex-protocols-go v1.0.58 h1:W8pZ2LOlJm/mo/UOJjkLWNVHs0jQmkoa8qoI5A1WVyY=
+github.com/PretendoNetwork/nex-protocols-go v1.0.58/go.mod h1:136762CMIcAsTZDrt4W7gDE4ppiBuc9zN2QFOHESjS8=
 github.com/PretendoNetwork/plogger-go v1.0.4 h1:PF7xHw9eDRHH+RsAP9tmAE7fG0N0p6H4iPwHKnsoXwc=
 github.com/PretendoNetwork/plogger-go v1.0.4/go.mod h1:7kD6M4vPq1JL4LTuPg6kuB1OvUBOwQOtAvTaUwMbwvU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/matchmake-extension/auto_matchmake_postpone.go
+++ b/matchmake-extension/auto_matchmake_postpone.go
@@ -7,7 +7,7 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 )
 
-func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, anyGathering *nex.DataHolder, message string) uint32 {
+func autoMatchmake_Postpone(err error, packet nex.PacketInterface, callID uint32, anyGathering *nex.DataHolder, message string) uint32 {
 	if commonMatchmakeExtensionProtocol.cleanupSearchMatchmakeSessionHandler == nil {
 		common_globals.Logger.Warning("MatchmakeExtension::AutoMatchmake_Postpone missing CleanupSearchMatchmakeSessionHandler!")
 		return nex.Errors.Core.NotImplemented
@@ -19,6 +19,7 @@ func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, anyGat
 	}
 
 	server := commonMatchmakeExtensionProtocol.server
+	client := packet.Sender()
 
 	// A client may disconnect from a session without leaving reliably,
 	// so let's make sure the client is removed from the session
@@ -78,8 +79,8 @@ func autoMatchmake_Postpone(err error, client *nex.Client, callID uint32, anyGat
 		responsePacket, _ = nex.NewPacketV1(client, nil)
 		responsePacket.SetVersion(1)
 	}
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmake-extension/auto_matchmake_with_param_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_param_postpone.go
@@ -7,13 +7,14 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 )
 
-func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint32, autoMatchmakeParam *match_making_types.AutoMatchmakeParam) uint32 {
+func autoMatchmakeWithParam_Postpone(err error, packet nex.PacketInterface, callID uint32, autoMatchmakeParam *match_making_types.AutoMatchmakeParam) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
 	server := commonMatchmakeExtensionProtocol.server
+	client := packet.Sender()
 
 	// A client may disconnect from a session without leaving reliably,
 	// so let's make sure the client is removed from the session
@@ -64,8 +65,8 @@ func autoMatchmakeWithParam_Postpone(err error, client *nex.Client, callID uint3
 		responsePacket, _ = nex.NewPacketV1(client, nil)
 		responsePacket.SetVersion(1)
 	}
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
@@ -7,13 +7,14 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 )
 
-func autoMatchmakeWithSearchCriteria_Postpone(err error, client *nex.Client, callID uint32, lstSearchCriteria []*match_making_types.MatchmakeSessionSearchCriteria, anyGathering *nex.DataHolder, message string) uint32 {
+func autoMatchmakeWithSearchCriteria_Postpone(err error, packet nex.PacketInterface, callID uint32, lstSearchCriteria []*match_making_types.MatchmakeSessionSearchCriteria, anyGathering *nex.DataHolder, message string) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
 	server := commonMatchmakeExtensionProtocol.server
+	client := packet.Sender()
 
 	// * A client may disconnect from a session without leaving reliably,
 	// * so let's make sure the client is removed from the session
@@ -72,8 +73,8 @@ func autoMatchmakeWithSearchCriteria_Postpone(err error, client *nex.Client, cal
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmake-extension/browse_matchmake_session.go
+++ b/matchmake-extension/browse_matchmake_session.go
@@ -7,13 +7,15 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 )
 
-func browseMatchmakeSession(err error, client *nex.Client, callID uint32, searchCriteria *match_making_types.MatchmakeSessionSearchCriteria, resultRange *nex.ResultRange) uint32 {
+func browseMatchmakeSession(err error, packet nex.PacketInterface, callID uint32, searchCriteria *match_making_types.MatchmakeSessionSearchCriteria, resultRange *nex.ResultRange) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
 	server := commonMatchmakeExtensionProtocol.server
+	client := packet.Sender()
+
 	searchCriterias := []*match_making_types.MatchmakeSessionSearchCriteria{searchCriteria}
 
 	sessions := common_globals.FindSessionsByMatchmakeSessionSearchCriterias(client.PID(), searchCriterias, commonMatchmakeExtensionProtocol.gameSpecificMatchmakeSessionSearchCriteriaChecksHandler)
@@ -59,8 +61,8 @@ func browseMatchmakeSession(err error, client *nex.Client, callID uint32, search
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmake-extension/close_participation.go
+++ b/matchmake-extension/close_participation.go
@@ -6,11 +6,13 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 )
 
-func closeParticipation(err error, client *nex.Client, callID uint32, gid uint32) uint32 {
+func closeParticipation(err error, packet nex.PacketInterface, callID uint32, gid uint32) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
+
+	client := packet.Sender()
 
 	var session *common_globals.CommonMatchmakeSession
 	var ok bool
@@ -41,8 +43,8 @@ func closeParticipation(err error, client *nex.Client, callID uint32, gid uint32
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmake-extension/create_matchmake_session.go
+++ b/matchmake-extension/create_matchmake_session.go
@@ -7,12 +7,13 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 )
 
-func createMatchmakeSession(err error, client *nex.Client, callID uint32, anyGathering *nex.DataHolder, message string, participationCount uint16) uint32 {
+func createMatchmakeSession(err error, packet nex.PacketInterface, callID uint32, anyGathering *nex.DataHolder, message string, participationCount uint16) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
+	client := packet.Sender()
 	server := client.Server()
 
 	// A client may disconnect from a session without leaving reliably,
@@ -65,8 +66,8 @@ func createMatchmakeSession(err error, client *nex.Client, callID uint32, anyGat
 		responsePacket, _ = nex.NewPacketV1(client, nil)
 		responsePacket.SetVersion(1)
 	}
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmake-extension/create_matchmake_session.go
+++ b/matchmake-extension/create_matchmake_session.go
@@ -14,7 +14,7 @@ func createMatchmakeSession(err error, packet nex.PacketInterface, callID uint32
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonMatchmakeExtensionProtocol.server
 
 	// A client may disconnect from a session without leaving reliably,
 	// so let's make sure the client is removed from the session

--- a/matchmake-extension/create_matchmake_session_with_param.go
+++ b/matchmake-extension/create_matchmake_session_with_param.go
@@ -7,12 +7,13 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 )
 
-func createMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32, createMatchmakeSessionParam *match_making_types.CreateMatchmakeSessionParam) uint32 {
+func createMatchmakeSessionWithParam(err error, packet nex.PacketInterface, callID uint32, createMatchmakeSessionParam *match_making_types.CreateMatchmakeSessionParam) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
+	client := packet.Sender()
 	server := client.Server()
 
 	// * A client may disconnect from a session without leaving reliably,
@@ -53,8 +54,8 @@ func createMatchmakeSessionWithParam(err error, client *nex.Client, callID uint3
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmake-extension/create_matchmake_session_with_param.go
+++ b/matchmake-extension/create_matchmake_session_with_param.go
@@ -14,7 +14,7 @@ func createMatchmakeSessionWithParam(err error, packet nex.PacketInterface, call
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonMatchmakeExtensionProtocol.server
 
 	// * A client may disconnect from a session without leaving reliably,
 	// * so let's make sure the client is removed from all sessions

--- a/matchmake-extension/get_simple_playing_session.go
+++ b/matchmake-extension/get_simple_playing_session.go
@@ -27,7 +27,7 @@ func getSimplePlayingSession(err error, packet nex.PacketInterface, callID uint3
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonMatchmakeExtensionProtocol.server
 
 	if slices.Contains(listPID, client.PID()) {
 		listPID = remove(listPID, client.PID())

--- a/matchmake-extension/get_simple_playing_session.go
+++ b/matchmake-extension/get_simple_playing_session.go
@@ -20,12 +20,13 @@ func remove[T comparable](l []T, item T) []T {
 	return l
 }
 
-func getSimplePlayingSession(err error, client *nex.Client, callID uint32, listPID []uint32, includeLoginUser bool) uint32 {
+func getSimplePlayingSession(err error, packet nex.PacketInterface, callID uint32, listPID []uint32, includeLoginUser bool) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
+	client := packet.Sender()
 	server := client.Server()
 
 	if slices.Contains(listPID, client.PID()) {
@@ -91,8 +92,8 @@ func getSimplePlayingSession(err error, client *nex.Client, callID uint32, listP
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmake-extension/join_matchmake_session.go
+++ b/matchmake-extension/join_matchmake_session.go
@@ -6,12 +6,13 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 )
 
-func joinMatchmakeSession(err error, client *nex.Client, callID uint32, gid uint32, strMessage string) uint32 {
+func joinMatchmakeSession(err error, packet nex.PacketInterface, callID uint32, gid uint32, strMessage string) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
+	client := packet.Sender()
 	server := client.Server()
 
 	session, ok := common_globals.Sessions[gid]
@@ -52,8 +53,8 @@ func joinMatchmakeSession(err error, client *nex.Client, callID uint32, gid uint
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmake-extension/join_matchmake_session.go
+++ b/matchmake-extension/join_matchmake_session.go
@@ -13,7 +13,7 @@ func joinMatchmakeSession(err error, packet nex.PacketInterface, callID uint32, 
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonMatchmakeExtensionProtocol.server
 
 	session, ok := common_globals.Sessions[gid]
 	if !ok {

--- a/matchmake-extension/join_matchmake_session_with_param.go
+++ b/matchmake-extension/join_matchmake_session_with_param.go
@@ -14,7 +14,7 @@ func joinMatchmakeSessionWithParam(err error, packet nex.PacketInterface, callID
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonMatchmakeExtensionProtocol.server
 
 	session, ok := common_globals.Sessions[joinMatchmakeSessionParam.GID]
 	if !ok {

--- a/matchmake-extension/join_matchmake_session_with_param.go
+++ b/matchmake-extension/join_matchmake_session_with_param.go
@@ -7,12 +7,13 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 )
 
-func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32, joinMatchmakeSessionParam *match_making_types.JoinMatchmakeSessionParam) uint32 {
+func joinMatchmakeSessionWithParam(err error, packet nex.PacketInterface, callID uint32, joinMatchmakeSessionParam *match_making_types.JoinMatchmakeSessionParam) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
+	client := packet.Sender()
 	server := client.Server()
 
 	session, ok := common_globals.Sessions[joinMatchmakeSessionParam.GID]
@@ -50,8 +51,8 @@ func joinMatchmakeSessionWithParam(err error, client *nex.Client, callID uint32,
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmake-extension/modify_current_game_attribute.go
+++ b/matchmake-extension/modify_current_game_attribute.go
@@ -13,7 +13,7 @@ func modifyCurrentGameAttribute(err error, packet nex.PacketInterface, callID ui
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonMatchmakeExtensionProtocol.server
 
 	session, ok := common_globals.Sessions[gid]
 	if !ok {

--- a/matchmake-extension/modify_current_game_attribute.go
+++ b/matchmake-extension/modify_current_game_attribute.go
@@ -6,12 +6,13 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 )
 
-func modifyCurrentGameAttribute(err error, client *nex.Client, callID uint32, gid uint32, attribIndex uint32, newValue uint32) uint32 {
+func modifyCurrentGameAttribute(err error, packet nex.PacketInterface, callID uint32, gid uint32, attribIndex uint32, newValue uint32) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
+	client := packet.Sender()
 	server := client.Server()
 
 	session, ok := common_globals.Sessions[gid]
@@ -44,8 +45,8 @@ func modifyCurrentGameAttribute(err error, client *nex.Client, callID uint32, gi
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmake-extension/open_participation.go
+++ b/matchmake-extension/open_participation.go
@@ -6,11 +6,13 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 )
 
-func openParticipation(err error, client *nex.Client, callID uint32, gid uint32) uint32 {
+func openParticipation(err error, packet nex.PacketInterface, callID uint32, gid uint32) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
+
+	client := packet.Sender()
 
 	var session *common_globals.CommonMatchmakeSession
 	var ok bool
@@ -41,8 +43,8 @@ func openParticipation(err error, client *nex.Client, callID uint32, gid uint32)
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmake-extension/update_application_buffer.go
+++ b/matchmake-extension/update_application_buffer.go
@@ -13,7 +13,7 @@ func updateApplicationBuffer(err error, packet nex.PacketInterface, callID uint3
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonMatchmakeExtensionProtocol.server
 
 	session, ok := common_globals.Sessions[gid]
 	if !ok {

--- a/matchmake-extension/update_application_buffer.go
+++ b/matchmake-extension/update_application_buffer.go
@@ -6,12 +6,13 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 )
 
-func updateApplicationBuffer(err error, client *nex.Client, callID uint32, gid uint32, applicationBuffer []byte) uint32 {
+func updateApplicationBuffer(err error, packet nex.PacketInterface, callID uint32, gid uint32, applicationBuffer []byte) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
+	client := packet.Sender()
 	server := client.Server()
 
 	session, ok := common_globals.Sessions[gid]
@@ -36,8 +37,8 @@ func updateApplicationBuffer(err error, client *nex.Client, callID uint32, gid u
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmake-extension/update_progress_score.go
+++ b/matchmake-extension/update_progress_score.go
@@ -6,11 +6,13 @@ import (
 	matchmake_extension "github.com/PretendoNetwork/nex-protocols-go/matchmake-extension"
 )
 
-func updateProgressScore(err error, client *nex.Client, callID uint32, gid uint32, progressScore uint8) uint32 {
+func updateProgressScore(err error, packet nex.PacketInterface, callID uint32, gid uint32, progressScore uint8) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
+
+	client := packet.Sender()
 
 	session := common_globals.Sessions[gid]
 	if session == nil {
@@ -44,8 +46,8 @@ func updateProgressScore(err error, client *nex.Client, callID uint32, gid uint3
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmaking-ext/end_participation.go
+++ b/matchmaking-ext/end_participation.go
@@ -9,13 +9,15 @@ import (
 	notifications_types "github.com/PretendoNetwork/nex-protocols-go/notifications/types"
 )
 
-func endParticipation(err error, client *nex.Client, callID uint32, idGathering uint32, strMessage string) uint32 {
+func endParticipation(err error, packet nex.PacketInterface, callID uint32, idGathering uint32, strMessage string) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
 	server := commonMatchMakingExtProtocol.server
+	client := packet.Sender()
+
 	var session *common_globals.CommonMatchmakeSession
 	var ok bool
 	if session, ok = common_globals.Sessions[idGathering]; !ok {
@@ -64,8 +66,8 @@ func endParticipation(err error, client *nex.Client, callID uint32, idGathering 
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmaking/find_by_single_id.go
+++ b/matchmaking/find_by_single_id.go
@@ -13,7 +13,7 @@ func findBySingleID(err error, packet nex.PacketInterface, callID uint32, id uin
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonMatchMakingProtocol.server
 
 	session, ok := common_globals.Sessions[id]
 	if !ok {

--- a/matchmaking/find_by_single_id.go
+++ b/matchmaking/find_by_single_id.go
@@ -6,12 +6,13 @@ import (
 	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
 )
 
-func findBySingleID(err error, client *nex.Client, callID uint32, id uint32) uint32 {
+func findBySingleID(err error, packet nex.PacketInterface, callID uint32, id uint32) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
+	client := packet.Sender()
 	server := client.Server()
 
 	session, ok := common_globals.Sessions[id]
@@ -46,8 +47,8 @@ func findBySingleID(err error, client *nex.Client, callID uint32, id uint32) uin
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmaking/get_session_urls.go
+++ b/matchmaking/get_session_urls.go
@@ -6,11 +6,13 @@ import (
 	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
 )
 
-func getSessionURLs(err error, client *nex.Client, callID uint32, gid uint32) uint32 {
+func getSessionURLs(err error, packet nex.PacketInterface, callID uint32, gid uint32) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
+
+	client := packet.Sender()
 
 	session, ok := common_globals.Sessions[gid]
 	if !ok {
@@ -50,8 +52,8 @@ func getSessionURLs(err error, client *nex.Client, callID uint32, gid uint32) ui
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmaking/unregister_gathering.go
+++ b/matchmaking/unregister_gathering.go
@@ -8,13 +8,14 @@ import (
 	notifications_types "github.com/PretendoNetwork/nex-protocols-go/notifications/types"
 )
 
-func unregisterGathering(err error, client *nex.Client, callID uint32, idGathering uint32) uint32 {
+func unregisterGathering(err error, packet nex.PacketInterface, callID uint32, idGathering uint32) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
 	server := commonMatchMakingProtocol.server
+	client := packet.Sender()
 
 	var session *common_globals.CommonMatchmakeSession
 	var ok bool
@@ -50,8 +51,8 @@ func unregisterGathering(err error, client *nex.Client, callID uint32, idGatheri
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmaking/update_session_host.go
+++ b/matchmaking/update_session_host.go
@@ -8,11 +8,13 @@ import (
 	notifications_types "github.com/PretendoNetwork/nex-protocols-go/notifications/types"
 )
 
-func updateSessionHost(err error, client *nex.Client, callID uint32, gid uint32, isMigrateOwner bool) uint32 {
+func updateSessionHost(err error, packet nex.PacketInterface, callID uint32, gid uint32, isMigrateOwner bool) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
+
+	client := packet.Sender()
 
 	var session *common_globals.CommonMatchmakeSession
 	var ok bool
@@ -45,8 +47,8 @@ func updateSessionHost(err error, client *nex.Client, callID uint32, gid uint32,
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmaking/update_session_host_v1.go
+++ b/matchmaking/update_session_host_v1.go
@@ -6,11 +6,13 @@ import (
 	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
 )
 
-func updateSessionHostV1(err error, client *nex.Client, callID uint32, gid uint32) uint32 {
+func updateSessionHostV1(err error, packet nex.PacketInterface, callID uint32, gid uint32) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
+
+	client := packet.Sender()
 
 	var session *common_globals.CommonMatchmakeSession
 	var ok bool
@@ -43,8 +45,8 @@ func updateSessionHostV1(err error, client *nex.Client, callID uint32, gid uint3
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/matchmaking/update_session_url.go
+++ b/matchmaking/update_session_url.go
@@ -6,7 +6,7 @@ import (
 	match_making "github.com/PretendoNetwork/nex-protocols-go/match-making"
 )
 
-func updateSessionURL(err error, client *nex.Client, callID uint32, idGathering uint32, strURL string) uint32 {
+func updateSessionURL(err error, packet nex.PacketInterface, callID uint32, idGathering uint32, strURL string) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
@@ -18,6 +18,7 @@ func updateSessionURL(err error, client *nex.Client, callID uint32, idGathering 
 	}
 
 	server := commonMatchMakingProtocol.server
+	client := packet.Sender()
 
 	// * Mario Kart 7 seems to set an empty strURL, so I assume this is what the method does?
 	session.GameMatchmakeSession.Gathering.HostPID = client.PID()
@@ -46,8 +47,8 @@ func updateSessionURL(err error, client *nex.Client, callID uint32, idGathering 
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/nat-traversal/get_relay_signature_key.go
+++ b/nat-traversal/get_relay_signature_key.go
@@ -7,13 +7,15 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func getRelaySignatureKey(err error, client *nex.Client, callID uint32) uint32 {
+func getRelaySignatureKey(err error, packet nex.PacketInterface, callID uint32) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
+	client := packet.Sender()
 	server := commonNATTraversalProtocol.server
+
 	rmcResponseStream := nex.NewStreamOut(server)
 
 	rmcResponseStream.WriteInt32LE(0)
@@ -40,8 +42,8 @@ func getRelaySignatureKey(err error, client *nex.Client, callID uint32) uint32 {
 		responsePacket, _ = nex.NewPacketV1(client, nil)
 		responsePacket.SetVersion(1)
 	}
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/nat-traversal/report_nat_properties.go
+++ b/nat-traversal/report_nat_properties.go
@@ -7,13 +7,14 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func reportNATProperties(err error, client *nex.Client, callID uint32, natm uint32, natf uint32, rtt uint32) uint32 {
+func reportNATProperties(err error, packet nex.PacketInterface, callID uint32, natm uint32, natf uint32, rtt uint32) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
 	server := commonNATTraversalProtocol.server
+	client := packet.Sender()
 
 	stations := client.StationURLs()
 	for _, station := range stations {
@@ -41,8 +42,8 @@ func reportNATProperties(err error, client *nex.Client, callID uint32, natm uint
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/nat-traversal/report_nat_traversal_result.go
+++ b/nat-traversal/report_nat_traversal_result.go
@@ -7,12 +7,13 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func reportNATTraversalResult(err error, client *nex.Client, callID uint32, cid uint32, result bool, rtt uint32) uint32 {
+func reportNATTraversalResult(err error, packet nex.PacketInterface, callID uint32, cid uint32, result bool, rtt uint32) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
+	client := packet.Sender()
 	server := commonNATTraversalProtocol.server
 
 	rmcResponse := nex.NewRMCResponse(nat_traversal.ProtocolID, callID)
@@ -30,8 +31,8 @@ func reportNATTraversalResult(err error, client *nex.Client, callID uint32, cid 
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/nat-traversal/report_nat_traversal_result_detail.go
+++ b/nat-traversal/report_nat_traversal_result_detail.go
@@ -7,12 +7,13 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func reportNATTraversalResultDetail(err error, client *nex.Client, callID uint32, cid uint32, result bool, detail int32, rtt uint32) uint32 {
+func reportNATTraversalResultDetail(err error, packet nex.PacketInterface, callID uint32, cid uint32, result bool, detail int32, rtt uint32) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
+	client := packet.Sender()
 	server := commonNATTraversalProtocol.server
 
 	rmcResponse := nex.NewRMCResponse(nat_traversal.ProtocolID, callID)
@@ -30,8 +31,8 @@ func reportNATTraversalResultDetail(err error, client *nex.Client, callID uint32
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/nat-traversal/request_probe_initiation_ext.go
+++ b/nat-traversal/request_probe_initiation_ext.go
@@ -7,13 +7,15 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func requestProbeInitiationExt(err error, client *nex.Client, callID uint32, targetList []string, stationToProbe string) uint32 {
+func requestProbeInitiationExt(err error, packet nex.PacketInterface, callID uint32, targetList []string, stationToProbe string) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
+	client := packet.Sender()
 	server := commonNATTraversalProtocol.server
+
 	rmcResponse := nex.NewRMCResponse(nat_traversal.ProtocolID, callID)
 	rmcResponse.SetSuccess(nat_traversal.MethodRequestProbeInitiationExt, nil)
 
@@ -29,8 +31,8 @@ func requestProbeInitiationExt(err error, client *nex.Client, callID uint32, tar
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/ranking/get_cached_top_x_ranking.go
+++ b/ranking/get_cached_top_x_ranking.go
@@ -17,7 +17,7 @@ func getCachedTopXRanking(err error, packet nex.PacketInterface, callID uint32, 
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonRankingProtocol.server
 
 	if err != nil {
 		common_globals.Logger.Error(err.Error())

--- a/ranking/get_cached_top_x_ranking.go
+++ b/ranking/get_cached_top_x_ranking.go
@@ -10,12 +10,13 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func getCachedTopXRanking(err error, client *nex.Client, callID uint32, category uint32, orderParam *ranking_types.RankingOrderParam) uint32 {
+func getCachedTopXRanking(err error, packet nex.PacketInterface, callID uint32, category uint32, orderParam *ranking_types.RankingOrderParam) uint32 {
 	if commonRankingProtocol.getRankingsAndCountByCategoryAndRankingOrderParamHandler == nil {
 		common_globals.Logger.Warning("Ranking::GetCachedTopXRanking missing GetRankingsAndCountByCategoryAndRankingOrderParamHandler!")
 		return nex.Errors.Core.NotImplemented
 	}
 
+	client := packet.Sender()
 	server := client.Server()
 
 	if err != nil {
@@ -38,7 +39,7 @@ func getCachedTopXRanking(err error, client *nex.Client, callID uint32, category
 	rankingResult.RankDataList = rankDataList
 	rankingResult.TotalCount = totalCount
 	rankingResult.SinceTime = nex.NewDateTime(0x1f40420000) // * 2000-01-01T00:00:00.000Z, this is what the real server sends back
-		
+
 	pResult := ranking_types.NewRankingCachedResult()
 	serverTime := nex.NewDateTime(0)
 	pResult.CreatedTime = nex.NewDateTime(serverTime.UTC())
@@ -69,8 +70,8 @@ func getCachedTopXRanking(err error, client *nex.Client, callID uint32, category
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/ranking/get_cached_top_x_rankings.go
+++ b/ranking/get_cached_top_x_rankings.go
@@ -17,7 +17,7 @@ func getCachedTopXRankings(err error, packet nex.PacketInterface, callID uint32,
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonRankingProtocol.server
 
 	if err != nil {
 		common_globals.Logger.Error(err.Error())

--- a/ranking/get_common_data.go
+++ b/ranking/get_common_data.go
@@ -7,12 +7,13 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func getCommonData(err error, client *nex.Client, callID uint32, uniqueID uint64) uint32 {
+func getCommonData(err error, packet nex.PacketInterface, callID uint32, uniqueID uint64) uint32 {
 	if commonRankingProtocol.getCommonDataHandler == nil {
 		common_globals.Logger.Warning("Ranking::GetCommonData missing GetCommonDataHandler!")
 		return nex.Errors.Core.NotImplemented
 	}
 
+	client := packet.Sender()
 	server := client.Server()
 
 	if err != nil {
@@ -24,7 +25,7 @@ func getCommonData(err error, client *nex.Client, callID uint32, uniqueID uint64
 	if err != nil {
 		return nex.Errors.Ranking.NotFound
 	}
-		
+
 	rmcResponseStream := nex.NewStreamOut(server)
 	rmcResponseStream.WriteBuffer(commonData)
 	rmcResponseBody := rmcResponseStream.Bytes()
@@ -44,8 +45,8 @@ func getCommonData(err error, client *nex.Client, callID uint32, uniqueID uint64
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/ranking/get_common_data.go
+++ b/ranking/get_common_data.go
@@ -14,7 +14,7 @@ func getCommonData(err error, packet nex.PacketInterface, callID uint32, uniqueI
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonRankingProtocol.server
 
 	if err != nil {
 		common_globals.Logger.Error(err.Error())

--- a/ranking/get_ranking.go
+++ b/ranking/get_ranking.go
@@ -15,7 +15,7 @@ func getRanking(err error, packet nex.PacketInterface, callID uint32, rankingMod
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonRankingProtocol.server
 
 	if err != nil {
 		common_globals.Logger.Error(err.Error())

--- a/ranking/get_ranking.go
+++ b/ranking/get_ranking.go
@@ -8,12 +8,13 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func getRanking(err error, client *nex.Client, callID uint32, rankingMode uint8, category uint32, orderParam *ranking_types.RankingOrderParam, uniqueID uint64, principalID uint32) uint32 {
+func getRanking(err error, packet nex.PacketInterface, callID uint32, rankingMode uint8, category uint32, orderParam *ranking_types.RankingOrderParam, uniqueID uint64, principalID uint32) uint32 {
 	if commonRankingProtocol.getRankingsAndCountByCategoryAndRankingOrderParamHandler == nil {
 		common_globals.Logger.Warning("Ranking::GetRanking missing GetRankingsAndCountByCategoryAndRankingOrderParamHandler!")
 		return nex.Errors.Core.NotImplemented
 	}
-	
+
+	client := packet.Sender()
 	server := client.Server()
 
 	if err != nil {
@@ -58,8 +59,8 @@ func getRanking(err error, client *nex.Client, callID uint32, rankingMode uint8,
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/ranking/upload_common_data.go
+++ b/ranking/upload_common_data.go
@@ -7,12 +7,13 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func uploadCommonData(err error, client *nex.Client, callID uint32, commonData []byte, uniqueID uint64) uint32 {
+func uploadCommonData(err error, packet nex.PacketInterface, callID uint32, commonData []byte, uniqueID uint64) uint32 {
 	if commonRankingProtocol.uploadCommonDataHandler == nil {
 		common_globals.Logger.Warning("Ranking::UploadCommonData missing UploadCommonDataHandler!")
 		return nex.Errors.Core.NotImplemented
 	}
 
+	client := packet.Sender()
 	server := client.Server()
 
 	if err != nil {
@@ -25,7 +26,7 @@ func uploadCommonData(err error, client *nex.Client, callID uint32, commonData [
 		common_globals.Logger.Critical(err.Error())
 		return nex.Errors.Ranking.Unknown
 	}
-	
+
 	rmcResponse := nex.NewRMCResponse(ranking.ProtocolID, callID)
 	rmcResponse.SetSuccess(ranking.MethodUploadCommonData, nil)
 
@@ -41,8 +42,8 @@ func uploadCommonData(err error, client *nex.Client, callID uint32, commonData [
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/ranking/upload_common_data.go
+++ b/ranking/upload_common_data.go
@@ -14,7 +14,7 @@ func uploadCommonData(err error, packet nex.PacketInterface, callID uint32, comm
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonRankingProtocol.server
 
 	if err != nil {
 		common_globals.Logger.Error(err.Error())

--- a/ranking/upload_score.go
+++ b/ranking/upload_score.go
@@ -15,7 +15,7 @@ func uploadScore(err error, packet nex.PacketInterface, callID uint32, scoreData
 	}
 
 	client := packet.Sender()
-	server := client.Server()
+	server := commonRankingProtocol.server
 
 	if err != nil {
 		common_globals.Logger.Error(err.Error())

--- a/ranking/upload_score.go
+++ b/ranking/upload_score.go
@@ -8,12 +8,13 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func uploadScore(err error, client *nex.Client, callID uint32, scoreData *ranking_types.RankingScoreData, uniqueID uint64) uint32 {
+func uploadScore(err error, packet nex.PacketInterface, callID uint32, scoreData *ranking_types.RankingScoreData, uniqueID uint64) uint32 {
 	if commonRankingProtocol.insertRankingByPIDAndRankingScoreDataHandler == nil {
 		common_globals.Logger.Warning("Ranking::UploadScore missing InsertRankingByPIDAndRankingScoreDataHandler!")
 		return nex.Errors.Core.NotImplemented
 	}
 
+	client := packet.Sender()
 	server := client.Server()
 
 	if err != nil {
@@ -26,7 +27,7 @@ func uploadScore(err error, client *nex.Client, callID uint32, scoreData *rankin
 		common_globals.Logger.Critical(err.Error())
 		return nex.Errors.Ranking.Unknown
 	}
-	
+
 	rmcResponse := nex.NewRMCResponse(ranking.ProtocolID, callID)
 	rmcResponse.SetSuccess(ranking.MethodUploadScore, nil)
 
@@ -42,8 +43,8 @@ func uploadScore(err error, client *nex.Client, callID uint32, scoreData *rankin
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/secure-connection/register.go
+++ b/secure-connection/register.go
@@ -7,13 +7,14 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func register(err error, client *nex.Client, callID uint32, stationUrls []*nex.StationURL) uint32 {
+func register(err error, packet nex.PacketInterface, callID uint32, stationUrls []*nex.StationURL) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
 	server := commonSecureConnectionProtocol.server
+	client := packet.Sender()
 
 	nextConnectionID := uint32(server.ConnectionIDCounter().Increment())
 	client.SetConnectionID(nextConnectionID)
@@ -78,8 +79,8 @@ func register(err error, client *nex.Client, callID uint32, stationUrls []*nex.S
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/secure-connection/replace_url.go
+++ b/secure-connection/replace_url.go
@@ -7,13 +7,14 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func replaceURL(err error, client *nex.Client, callID uint32, oldStation *nex.StationURL, newStation *nex.StationURL) uint32 {
+func replaceURL(err error, packet nex.PacketInterface, callID uint32, oldStation *nex.StationURL, newStation *nex.StationURL) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
 
 	server := commonSecureConnectionProtocol.server
+	client := packet.Sender()
 
 	stations := client.StationURLs()
 	for i := 0; i < len(stations); i++ {
@@ -39,8 +40,8 @@ func replaceURL(err error, client *nex.Client, callID uint32, oldStation *nex.St
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/secure-connection/send_report.go
+++ b/secure-connection/send_report.go
@@ -7,7 +7,7 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func sendReport(err error, client *nex.Client, callID uint32, reportID uint32, reportData []byte) uint32 {
+func sendReport(err error, packet nex.PacketInterface, callID uint32, reportID uint32, reportData []byte) uint32 {
 	if commonSecureConnectionProtocol.createReportDBRecordHandler == nil {
 		common_globals.Logger.Warning("SecureConnection::SendReport missing CreateReportDBRecord!")
 		return nex.Errors.Core.NotImplemented
@@ -17,6 +17,8 @@ func sendReport(err error, client *nex.Client, callID uint32, reportID uint32, r
 		common_globals.Logger.Critical(err.Error())
 		return nex.Errors.Core.Unknown
 	}
+
+	client := packet.Sender()
 
 	err = commonSecureConnectionProtocol.createReportDBRecordHandler(client.PID(), reportID, reportData)
 	if err != nil {
@@ -39,8 +41,8 @@ func sendReport(err error, client *nex.Client, callID uint32, reportID uint32, r
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/ticket-granting/login.go
+++ b/ticket-granting/login.go
@@ -10,7 +10,7 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func login(err error, client *nex.Client, callID uint32, username string) uint32 {
+func login(err error, packet nex.PacketInterface, callID uint32, username string) uint32 {
 	if !commonTicketGrantingProtocol.allowInsecureLoginMethod {
 		return nex.Errors.Authentication.ValidationFailed
 	}
@@ -19,6 +19,8 @@ func login(err error, client *nex.Client, callID uint32, username string) uint32
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
+
+	client := packet.Sender()
 
 	var userPID uint32
 
@@ -96,8 +98,8 @@ func login(err error, client *nex.Client, callID uint32, username string) uint32
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/ticket-granting/login_ex.go
+++ b/ticket-granting/login_ex.go
@@ -10,11 +10,13 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func loginEx(err error, client *nex.Client, callID uint32, username string, oExtraData *nex.DataHolder) uint32 {
+func loginEx(err error, packet nex.PacketInterface, callID uint32, username string, oExtraData *nex.DataHolder) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
+
+	client := packet.Sender()
 
 	var userPID uint32
 
@@ -92,8 +94,8 @@ func loginEx(err error, client *nex.Client, callID uint32, username string, oExt
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/ticket-granting/request_ticket.go
+++ b/ticket-granting/request_ticket.go
@@ -7,11 +7,13 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func requestTicket(err error, client *nex.Client, callID uint32, userPID uint32, targetPID uint32) uint32 {
+func requestTicket(err error, packet nex.PacketInterface, callID uint32, userPID uint32, targetPID uint32) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
+
+	client := packet.Sender()
 
 	encryptedTicket, errorCode := generateTicket(userPID, targetPID)
 
@@ -43,8 +45,8 @@ func requestTicket(err error, client *nex.Client, callID uint32, userPID uint32,
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 

--- a/utility/acquire_nex_unique_id.go
+++ b/utility/acquire_nex_unique_id.go
@@ -7,11 +7,13 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/globals"
 )
 
-func acquireNexUniqueID(err error, client *nex.Client, callID uint32) uint32 {
+func acquireNexUniqueID(err error, packet nex.PacketInterface, callID uint32) uint32 {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.Errors.Core.InvalidArgument
 	}
+
+	client := packet.Sender()
 
 	var pNexUniqueID uint64
 
@@ -44,8 +46,8 @@ func acquireNexUniqueID(err error, client *nex.Client, callID uint32) uint32 {
 		responsePacket.SetVersion(1)
 	}
 
-	responsePacket.SetSource(0xA1)
-	responsePacket.SetDestination(0xAF)
+	responsePacket.SetSource(packet.Destination())
+	responsePacket.SetDestination(packet.Source())
 	responsePacket.SetType(nex.DataPacket)
 	responsePacket.SetPayload(rmcResponseBytes)
 


### PR DESCRIPTION
Brings common up to date with the latest nex-protocols-go release using `nex.PacketInterface` instead of `*nex.Client`