### PR TITLE
ticket-granting: Set the StructureVersion for NEX >3.5

### DIFF
--- a/ticket-granting/login.go
+++ b/ticket-granting/login.go
@@ -66,6 +66,10 @@ func (commonProtocol *CommonProtocol) login(err error, packet nex.PacketInterfac
 		pConnectionData.SpecialProtocols = specialProtocols
 		pConnectionData.StationURLSpecialProtocols = commonProtocol.StationURLSpecialProtocols
 		pConnectionData.Time = types.NewDateTime(0).Now()
+
+		if endpoint.LibraryVersions().Main.GreaterOrEqual("v3.5.0") {
+			pConnectionData.StructureVersion = 1
+		}
 	}
 
 	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())

--- a/ticket-granting/login_ex.go
+++ b/ticket-granting/login_ex.go
@@ -64,6 +64,10 @@ func (commonProtocol *CommonProtocol) loginEx(err error, packet nex.PacketInterf
 		pConnectionData.SpecialProtocols = specialProtocols
 		pConnectionData.StationURLSpecialProtocols = commonProtocol.StationURLSpecialProtocols
 		pConnectionData.Time = types.NewDateTime(0).Now()
+
+		if endpoint.LibraryVersions().Main.GreaterOrEqual("v3.5.0") {
+			pConnectionData.StructureVersion = 1
+		}
 	}
 
 	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())


### PR DESCRIPTION
Required for games such as Minecraft: Wii U Edition. This was added last year in e6b3e0b8425a343e1f0b42c6288a1573412e6b13 but reverted right after in 01db10686f581902c1fa8fdf6e6fd8c00d23ee6c, with the note that this is handled in nex-go - but I can't find any of that code today or any of the commits related to it, so I'm not sure what happened.

Happy to re-file against nex-go if someone's willing to point me in the right direction there.