### PR TITLE
feat!(datastore): Add requesting PID to GetObjectInfosByDataStoreSearchParam

### DIFF
--- a/datastore/protocol.go
+++ b/datastore/protocol.go
@@ -37,7 +37,7 @@ type CommonProtocol struct {
 	RateObjectWithPassword                       func(dataID *types.PrimitiveU64, slot *types.PrimitiveU8, ratingValue *types.PrimitiveS32, accessPassword *types.PrimitiveU64) (*datastore_types.DataStoreRatingInfo, *nex.Error)
 	DeleteObjectByDataIDWithPassword             func(dataID *types.PrimitiveU64, password *types.PrimitiveU64) *nex.Error
 	DeleteObjectByDataID                         func(dataID *types.PrimitiveU64) *nex.Error
-	GetObjectInfosByDataStoreSearchParam         func(param *datastore_types.DataStoreSearchParam) ([]*datastore_types.DataStoreMetaInfo, uint32, *nex.Error)
+	GetObjectInfosByDataStoreSearchParam         func(param *datastore_types.DataStoreSearchParam, pid *types.PID) ([]*datastore_types.DataStoreMetaInfo, uint32, *nex.Error)
 	GetObjectOwnerByDataID                       func(dataID *types.PrimitiveU64) (uint32, *nex.Error)
 	OnAfterDeleteObject                          func(packet nex.PacketInterface, param *datastore_types.DataStoreDeleteParam)
 	OnAfterGetMeta                               func(packet nex.PacketInterface, param *datastore_types.DataStoreGetMetaParam)

--- a/datastore/search_object.go
+++ b/datastore/search_object.go
@@ -29,7 +29,7 @@ func (commonProtocol *CommonProtocol) searchObject(err error, packet nex.PacketI
 	// * DataStoreSearchParam contains a ResultRange to limit the
 	// * returned results. TotalCount is the total matching objects
 	// * in the database, whereas objects is the limited results
-	objects, totalCount, errCode := commonProtocol.GetObjectInfosByDataStoreSearchParam(param)
+	objects, totalCount, errCode := commonProtocol.GetObjectInfosByDataStoreSearchParam(param, connection.PID())
 	if errCode != nil {
 		return nil, errCode
 	}


### PR DESCRIPTION
This is required for PUYOPUYOTETRIS, which doesn't use the perfectly good ownerPID field and instead sets a search target to mean "your own account". Very cool.

Breaking API change, but I don't think there are actually any consumers of the v2 DataStore API anyway?