### PR TITLE
feat(matchmake-extension): Lie about permission checks for CloseParticipation

### DIFF
--- a/matchmake-extension/close_participation.go
+++ b/matchmake-extension/close_participation.go
@@ -21,11 +21,11 @@ func (commonProtocol *CommonProtocol) closeParticipation(err error, packet nex.P
 	connection := packet.Sender().(*nex.PRUDPConnection)
 	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
 
-	if !session.GameMatchmakeSession.Gathering.OwnerPID.Equals(connection.PID()) {
-		return nil, nex.NewError(nex.ResultCodes.RendezVous.PermissionDenied, "change_error")
+	// * PUYOPUYOTETRIS has everyone send CloseParticipation here, not just the owner of the room.
+	// * So, if a non-owner asks, just lie and claim success without actually changing anything.
+	if session.GameMatchmakeSession.Gathering.OwnerPID.Equals(connection.PID()) {
+		session.GameMatchmakeSession.OpenParticipation = types.NewPrimitiveBool(false)
 	}
-
-	session.GameMatchmakeSession.OpenParticipation = types.NewPrimitiveBool(false)
 
 	rmcResponse := nex.NewRMCSuccess(endpoint, nil)
 	rmcResponse.ProtocolID = matchmake_extension.ProtocolID


### PR DESCRIPTION
PUYOPUYOTETRIS has all users send this packet, which is silly. If we send an error as we should, it aborts the match.
For users where it won't do anything, still claim success instead of sending an error.

I also considered introducing a configurable toggle on CommonProtocol to enable and disable this behaviour game-by-game, but couldn't find a clean way to do that.

The only weird behaviour I can think of is that `OnAfterCloseParticipation` still gets called even in a lying situation, so callers might have to account for participation not *actually* being closed.