### PR TITLE
feat!(ranking): Add new methods for the different ranking modes on GetRanking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ go.work.sum
 
 # custom
 .vscode
+.idea
 .env
 build
 log

--- a/ranking/get_ranking.go
+++ b/ranking/get_ranking.go
@@ -10,31 +10,6 @@ import (
 )
 
 func (commonProtocol *CommonProtocol) getRanking(err error, packet nex.PacketInterface, callID uint32, rankingMode types.UInt8, category types.UInt32, orderParam ranking_types.RankingOrderParam, uniqueID types.UInt64, principalID types.PID) (*nex.RMCMessage, *nex.Error) {
-	if commonProtocol.GetRankingsAndCountByCategoryAndRankingOrderParam == nil {
-		common_globals.Logger.Warning("Ranking::GetRanking missing GetRankingsAndCountByCategoryAndRankingOrderParam!")
-		return nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "change_error")
-	}
-
-	if commonProtocol.GetNearbyRankingsAndCountByCategoryAndRankingOrderParam == nil {
-		common_globals.Logger.Warning("Ranking::GetRanking missing GetNearbyRankingsAndCountByCategoryAndRankingOrderParam!")
-		return nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "change_error")
-	}
-
-	if commonProtocol.GetFriendsRankingsAndCountByCategoryAndRankingOrderParam == nil {
-		common_globals.Logger.Warning("Ranking::GetRanking missing GetFriendsRankingsAndCountByCategoryAndRankingOrderParam!")
-		return nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "change_error")
-	}
-
-	if commonProtocol.GetNearbyFriendsRankingsAndCountByCategoryAndRankingOrderParam == nil {
-		common_globals.Logger.Warning("Ranking::GetRanking missing GetNearbyFriendsRankingsAndCountByCategoryAndRankingOrderParam!")
-		return nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "change_error")
-	}
-
-	if commonProtocol.GetOwnRankingByCategoryAndRankingOrderParam == nil {
-		common_globals.Logger.Warning("Ranking::GetRanking missing GetOwnRankingByCategoryAndRankingOrderParam!")
-		return nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "change_error")
-	}
-
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nil, nex.NewError(nex.ResultCodes.Ranking.InvalidArgument, "change_error")
@@ -53,15 +28,40 @@ func (commonProtocol *CommonProtocol) getRanking(err error, packet nex.PacketInt
 
 	switch constants.RankingMode(rankingMode) {
 	case constants.RankingModeRange:
+		if commonProtocol.GetRankingsAndCountByCategoryAndRankingOrderParam == nil {
+			common_globals.Logger.Warning("Ranking::GetRanking missing GetRankingsAndCountByCategoryAndRankingOrderParam!")
+			return nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "change_error")
+		}
+
 		rankDataList, totalCount, err = commonProtocol.GetRankingsAndCountByCategoryAndRankingOrderParam(category, orderParam)
 	case constants.RankingModeNear:
+		if commonProtocol.GetNearbyRankingsAndCountByCategoryAndRankingOrderParam == nil {
+			common_globals.Logger.Warning("Ranking::GetRanking missing GetNearbyRankingsAndCountByCategoryAndRankingOrderParam!")
+			return nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "change_error")
+		}
+
 		rankDataList, totalCount, err = commonProtocol.GetNearbyRankingsAndCountByCategoryAndRankingOrderParam(callerPID, category, orderParam)
 	case constants.RankingModeFriendRange:
+		if commonProtocol.GetFriendsRankingsAndCountByCategoryAndRankingOrderParam == nil {
+			common_globals.Logger.Warning("Ranking::GetRanking missing GetFriendsRankingsAndCountByCategoryAndRankingOrderParam!")
+			return nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "change_error")
+		}
+
 		rankDataList, totalCount, err = commonProtocol.GetFriendsRankingsAndCountByCategoryAndRankingOrderParam(callerPID, category, orderParam)
 	case constants.RankingModeFriendNear:
+		if commonProtocol.GetNearbyFriendsRankingsAndCountByCategoryAndRankingOrderParam == nil {
+			common_globals.Logger.Warning("Ranking::GetRanking missing GetNearbyFriendsRankingsAndCountByCategoryAndRankingOrderParam!")
+			return nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "change_error")
+		}
+
 		rankDataList, totalCount, err = commonProtocol.GetNearbyFriendsRankingsAndCountByCategoryAndRankingOrderParam(callerPID, category, orderParam)
 	case constants.RankingModeUser:
 	default:
+		if commonProtocol.GetOwnRankingByCategoryAndRankingOrderParam == nil {
+			common_globals.Logger.Warning("Ranking::GetRanking missing GetOwnRankingByCategoryAndRankingOrderParam!")
+			return nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "change_error")
+		}
+
 		rankDataList, totalCount, err = commonProtocol.GetOwnRankingByCategoryAndRankingOrderParam(callerPID, category, orderParam)
 	}
 

--- a/ranking/get_ranking.go
+++ b/ranking/get_ranking.go
@@ -42,10 +42,10 @@ func (commonProtocol *CommonProtocol) getRanking(err error, packet nex.PacketInt
 
 	connection := packet.Sender()
 	endpoint := connection.Endpoint()
-	callerPid := principalID
+	callerPID := principalID
 	// * 0 = "own ranking"
-	if callerPid == 0 {
-		callerPid = connection.PID()
+	if callerPID == 0 {
+		callerPID = connection.PID()
 	}
 
 	var rankDataList types.List[ranking_types.RankingRankData]
@@ -55,14 +55,14 @@ func (commonProtocol *CommonProtocol) getRanking(err error, packet nex.PacketInt
 	case constants.RankingModeRange:
 		rankDataList, totalCount, err = commonProtocol.GetRankingsAndCountByCategoryAndRankingOrderParam(category, orderParam)
 	case constants.RankingModeNear:
-		rankDataList, totalCount, err = commonProtocol.GetNearbyRankingsAndCountByCategoryAndRankingOrderParam(callerPid, category, orderParam)
+		rankDataList, totalCount, err = commonProtocol.GetNearbyRankingsAndCountByCategoryAndRankingOrderParam(callerPID, category, orderParam)
 	case constants.RankingModeFriendRange:
-		rankDataList, totalCount, err = commonProtocol.GetFriendsRankingsAndCountByCategoryAndRankingOrderParam(callerPid, category, orderParam)
+		rankDataList, totalCount, err = commonProtocol.GetFriendsRankingsAndCountByCategoryAndRankingOrderParam(callerPID, category, orderParam)
 	case constants.RankingModeFriendNear:
-		rankDataList, totalCount, err = commonProtocol.GetNearbyFriendsRankingsAndCountByCategoryAndRankingOrderParam(callerPid, category, orderParam)
+		rankDataList, totalCount, err = commonProtocol.GetNearbyFriendsRankingsAndCountByCategoryAndRankingOrderParam(callerPID, category, orderParam)
 	case constants.RankingModeUser:
 	default:
-		rankDataList, totalCount, err = commonProtocol.GetOwnRankingByCategoryAndRankingOrderParam(callerPid, category, orderParam)
+		rankDataList, totalCount, err = commonProtocol.GetOwnRankingByCategoryAndRankingOrderParam(callerPID, category, orderParam)
 	}
 
 	if err != nil {

--- a/ranking/get_ranking.go
+++ b/ranking/get_ranking.go
@@ -56,13 +56,15 @@ func (commonProtocol *CommonProtocol) getRanking(err error, packet nex.PacketInt
 
 		rankDataList, totalCount, err = commonProtocol.GetNearbyFriendsRankingsAndCountByCategoryAndRankingOrderParam(callerPID, category, orderParam)
 	case constants.RankingModeUser:
-	default:
 		if commonProtocol.GetOwnRankingByCategoryAndRankingOrderParam == nil {
 			common_globals.Logger.Warning("Ranking::GetRanking missing GetOwnRankingByCategoryAndRankingOrderParam!")
 			return nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "change_error")
 		}
 
 		rankDataList, totalCount, err = commonProtocol.GetOwnRankingByCategoryAndRankingOrderParam(callerPID, category, orderParam)
+	default:
+		common_globals.Logger.Errorf("Unknown RankingMode %v!", rankingMode)
+		return nil, nex.NewError(nex.ResultCodes.Ranking.InvalidArgument, "Unknown RankingMode")
 	}
 
 	if err != nil {

--- a/ranking/protocol.go
+++ b/ranking/protocol.go
@@ -8,18 +8,22 @@ import (
 )
 
 type CommonProtocol struct {
-	endpoint                                          nex.EndpointInterface
-	protocol                                          ranking.Interface
-	GetCommonData                                     func(uniqueID types.UInt64) (types.Buffer, error)
-	UploadCommonData                                  func(pid types.PID, uniqueID types.UInt64, commonData types.Buffer) error
-	InsertRankingByPIDAndRankingScoreData             func(pid types.PID, rankingScoreData ranking_types.RankingScoreData, uniqueID types.UInt64) error
-	GetRankingsAndCountByCategoryAndRankingOrderParam func(category types.UInt32, rankingOrderParam ranking_types.RankingOrderParam) (types.List[ranking_types.RankingRankData], uint32, error)
-	OnAfterGetCachedTopXRanking                       func(packet nex.PacketInterface, category types.UInt32, orderParam ranking_types.RankingOrderParam)
-	OnAfterGetCachedTopXRankings                      func(packet nex.PacketInterface, categories types.List[types.UInt32], orderParams types.List[ranking_types.RankingOrderParam])
-	OnAfterGetCommonData                              func(packet nex.PacketInterface, uniqueID types.UInt64)
-	OnAfterGetRanking                                 func(packet nex.PacketInterface, rankingMode types.UInt8, category types.UInt32, orderParam ranking_types.RankingOrderParam, uniqueID types.UInt64, principalID types.PID)
-	OnAfterUploadCommonData                           func(packet nex.PacketInterface, commonData types.Buffer, uniqueID types.UInt64)
-	OnAfterUploadScore                                func(packet nex.PacketInterface, scoreData ranking_types.RankingScoreData, uniqueID types.UInt64)
+	endpoint                                                       nex.EndpointInterface
+	protocol                                                       ranking.Interface
+	GetCommonData                                                  func(uniqueID types.UInt64) (types.Buffer, error)
+	UploadCommonData                                               func(pid types.PID, uniqueID types.UInt64, commonData types.Buffer) error
+	InsertRankingByPIDAndRankingScoreData                          func(pid types.PID, rankingScoreData ranking_types.RankingScoreData, uniqueID types.UInt64) error
+	GetRankingsAndCountByCategoryAndRankingOrderParam              func(category types.UInt32, rankingOrderParam ranking_types.RankingOrderParam) (types.List[ranking_types.RankingRankData], uint32, error)
+	GetNearbyRankingsAndCountByCategoryAndRankingOrderParam        func(pid types.PID, category types.UInt32, rankingOrderParam ranking_types.RankingOrderParam) (types.List[ranking_types.RankingRankData], uint32, error)
+	GetFriendsRankingsAndCountByCategoryAndRankingOrderParam       func(pid types.PID, category types.UInt32, rankingOrderParam ranking_types.RankingOrderParam) (types.List[ranking_types.RankingRankData], uint32, error)
+	GetNearbyFriendsRankingsAndCountByCategoryAndRankingOrderParam func(pid types.PID, category types.UInt32, rankingOrderParam ranking_types.RankingOrderParam) (types.List[ranking_types.RankingRankData], uint32, error)
+	GetOwnRankingByCategoryAndRankingOrderParam                    func(pid types.PID, category types.UInt32, rankingOrderParam ranking_types.RankingOrderParam) (types.List[ranking_types.RankingRankData], uint32, error)
+	OnAfterGetCachedTopXRanking                                    func(packet nex.PacketInterface, category types.UInt32, orderParam ranking_types.RankingOrderParam)
+	OnAfterGetCachedTopXRankings                                   func(packet nex.PacketInterface, categories types.List[types.UInt32], orderParams types.List[ranking_types.RankingOrderParam])
+	OnAfterGetCommonData                                           func(packet nex.PacketInterface, uniqueID types.UInt64)
+	OnAfterGetRanking                                              func(packet nex.PacketInterface, rankingMode types.UInt8, category types.UInt32, orderParam ranking_types.RankingOrderParam, uniqueID types.UInt64, principalID types.PID)
+	OnAfterUploadCommonData                                        func(packet nex.PacketInterface, commonData types.Buffer, uniqueID types.UInt64)
+	OnAfterUploadScore                                             func(packet nex.PacketInterface, scoreData ranking_types.RankingScoreData, uniqueID types.UInt64)
 }
 
 // NewCommonProtocol returns a new CommonProtocol


### PR DESCRIPTION
There's 5 different types of GetRanking call, asking for:
- global leaderboards
- global leaderboards, nearby to your own rank
- only your friends
- only your friends, nearby to your own rank
- your own ranking only

These are pretty fundamentally different requests that would need different db queries, etc. at the implementation level. Notably all but the first need knowledge of the PID of the user making the request (to get their rank and their friends).


### Changes:

Add new methods to the protocol for each of these use cases.

Submitting as a draft because I *know* `if rankingMode.Value == 0 {` is the wrong way to do it, but I couldn't find any other protocol with constants like that for me to reference against. If someone count point out where I should define constants for this sort of thing I'll happily clean up the magic numbers.

There's a highly WIP implementation of this API here: https://github.com/ashquarky/puyo-wiiu/blob/ranking/datastore/puyo_ranking.go

Note the dramatically different database requests needed for each mode.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.