### PR TITLE
feat(secure-connection): Add methods for NEX 1

### DIFF
--- a/secure-connection/protocol.go
+++ b/secure-connection/protocol.go
@@ -11,6 +11,8 @@ type CommonProtocol struct {
 	protocol             secure_connection.Interface
 	CreateReportDBRecord func(pid *types.PID, reportID *types.PrimitiveU32, reportData *types.QBuffer) error
 	OnAfterRegister      func(packet nex.PacketInterface, vecMyURLs *types.List[*types.StationURL])
+	OnAfterRequestURLs   func(packet nex.PacketInterface, cidTarget *types.PrimitiveU32, pidTarget *types.PID)
+	OnAfterRegisterEx    func(packet nex.PacketInterface, vecMyURLs *types.List[*types.StationURL], hCustomData *types.AnyDataHolder)
 	OnAfterReplaceURL    func(packet nex.PacketInterface, target *types.StationURL, url *types.StationURL)
 	OnAfterSendReport    func(packet nex.PacketInterface, reportID *types.PrimitiveU32, reportData *types.QBuffer)
 }
@@ -23,6 +25,8 @@ func NewCommonProtocol(protocol secure_connection.Interface) *CommonProtocol {
 	}
 
 	protocol.SetHandlerRegister(commonProtocol.register)
+	protocol.SetHandlerRequestURLs(commonProtocol.requestURLs)
+	protocol.SetHandlerRegisterEx(commonProtocol.registerEx)
 	protocol.SetHandlerReplaceURL(commonProtocol.replaceURL)
 	protocol.SetHandlerSendReport(commonProtocol.sendReport)
 

--- a/secure-connection/register_ex.go
+++ b/secure-connection/register_ex.go
@@ -1,0 +1,114 @@
+package secureconnection
+
+import (
+	"net"
+
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/constants"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	secure_connection "github.com/PretendoNetwork/nex-protocols-go/v2/secure-connection"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+func (commonProtocol *CommonProtocol) registerEx(err error, packet nex.PacketInterface, callID uint32, vecMyURLs *types.List[*types.StationURL], hCustomData *types.AnyDataHolder) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "change_error")
+	}
+
+	// TODO - VALIDATE hCustomData!
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint()
+
+	// * vecMyURLs may contain multiple StationURLs. Search them all
+	var localStation *types.StationURL
+	var publicStation *types.StationURL
+
+	for _, stationURL := range vecMyURLs.Slice() {
+		natf, ok := stationURL.NATFiltering()
+		if !ok {
+			continue
+		}
+
+		natm, ok := stationURL.NATMapping()
+		if !ok {
+			continue
+		}
+
+		// * Station reports itself as being non-public (local)
+		if localStation == nil && !stationURL.IsPublic() {
+			localStation = stationURL.Copy().(*types.StationURL)
+		}
+
+		// * Still did not find the station, trying heuristics
+		if localStation == nil && natf == constants.UnknownNATFiltering && natm == constants.UnknownNATMapping {
+			localStation = stationURL.Copy().(*types.StationURL)
+		}
+
+		if publicStation == nil && stationURL.IsPublic() {
+			publicStation = stationURL.Copy().(*types.StationURL)
+		}
+	}
+
+	if localStation == nil {
+		common_globals.Logger.Error("Failed to find local station")
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "change_error")
+	}
+
+	if publicStation == nil {
+		publicStation = localStation.Copy().(*types.StationURL)
+
+		var address string
+		var port uint16
+
+		// * We have to duplicate this because Go automatically breaks on switch statements
+		switch clientAddress := connection.Address().(type) {
+		case *net.UDPAddr:
+			address = clientAddress.IP.String()
+			port = uint16(clientAddress.Port)
+		case *net.TCPAddr:
+			address = clientAddress.IP.String()
+			port = uint16(clientAddress.Port)
+		}
+
+		publicStation.SetAddress(address)
+		publicStation.SetPortNumber(port)
+		publicStation.SetNATFiltering(constants.UnknownNATFiltering)
+		publicStation.SetNATMapping(constants.UnknownNATMapping)
+		publicStation.SetType(uint8(constants.StationURLFlagPublic) | uint8(constants.StationURLFlagBehindNAT))
+	}
+
+	localStation.SetPrincipalID(connection.PID())
+	publicStation.SetPrincipalID(connection.PID())
+
+	localStation.SetRVConnectionID(connection.ID)
+	publicStation.SetRVConnectionID(connection.ID)
+
+	connection.StationURLs.Append(localStation)
+	connection.StationURLs.Append(publicStation)
+
+	retval := types.NewQResultSuccess(nex.ResultCodes.Core.Unknown)
+	pidConnectionID := types.NewPrimitiveU32(connection.ID)
+	urlPublic := types.NewString(publicStation.EncodeToString())
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	retval.WriteTo(rmcResponseStream)
+	pidConnectionID.WriteTo(rmcResponseStream)
+	urlPublic.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = secure_connection.ProtocolID
+	rmcResponse.MethodID = secure_connection.MethodRegisterEx
+	rmcResponse.CallID = callID
+
+	if commonProtocol.OnAfterRegisterEx != nil {
+		go commonProtocol.OnAfterRegisterEx(packet, vecMyURLs, hCustomData)
+	}
+
+	return rmcResponse, nil
+}

--- a/secure-connection/request_urls.go
+++ b/secure-connection/request_urls.go
@@ -1,0 +1,50 @@
+package secureconnection
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	secure_connection "github.com/PretendoNetwork/nex-protocols-go/v2/secure-connection"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+func (commonProtocol *CommonProtocol) requestURLs(err error, packet nex.PacketInterface, callID uint32, cidTarget *types.PrimitiveU32, pidTarget *types.PID) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "change_error")
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+
+	// TODO - Is this correct?
+	requestedConnection := endpoint.FindConnectionByID(cidTarget.Value)
+	if requestedConnection == nil {
+		requestedConnection = endpoint.FindConnectionByPID(pidTarget.Value())
+	}
+
+	if requestedConnection == nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "change_error")
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	retval := types.NewPrimitiveBool(true)
+	retval.WriteTo(rmcResponseStream)
+
+	plstURLs := requestedConnection.StationURLs
+	plstURLs.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = secure_connection.ProtocolID
+	rmcResponse.MethodID = secure_connection.MethodRequestURLs
+	rmcResponse.CallID = callID
+
+	if commonProtocol.OnAfterRequestURLs != nil {
+		go commonProtocol.OnAfterRequestURLs(packet, cidTarget, pidTarget)
+	}
+
+	return rmcResponse, nil
+}


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

Add `SecureConnection::RegisterEx` used in all NEX 1 games and `SecureConnection::RequestURLs` used on NEX 1 matchmaking for getting the station URLs of a matchmake session

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.