### PR TITLE
feat: Add extension point for CanJoinMatchmakeSession

### DIFF
--- a/matchmake-extension/join_matchmake_session.go
+++ b/matchmake-extension/join_matchmake_session.go
@@ -38,7 +38,12 @@ func (commonProtocol *CommonProtocol) joinMatchmakeSession(err error, packet nex
 		return nil, nex.NewError(nex.ResultCodes.RendezVous.PermissionDenied, "change_error")
 	}
 
-	nexError = common_globals.CanJoinMatchmakeSession(commonProtocol.manager, connection.PID(), joinedMatchmakeSession)
+	// * Allow game servers to do their own permissions checks
+	if commonProtocol.CanJoinMatchmakeSession != nil {
+		nexError = commonProtocol.CanJoinMatchmakeSession(commonProtocol.manager, connection.PID(), joinedMatchmakeSession)
+	} else {
+		nexError = common_globals.CanJoinMatchmakeSession(commonProtocol.manager, connection.PID(), joinedMatchmakeSession)
+	}
 	if nexError != nil {
 		commonProtocol.manager.Mutex.Unlock()
 		return nil, nexError

--- a/matchmake-extension/join_matchmake_session_ex.go
+++ b/matchmake-extension/join_matchmake_session_ex.go
@@ -38,7 +38,12 @@ func (commonProtocol *CommonProtocol) joinMatchmakeSessionEx(err error, packet n
 		return nil, nex.NewError(nex.ResultCodes.RendezVous.PermissionDenied, "change_error")
 	}
 
-	nexError = common_globals.CanJoinMatchmakeSession(commonProtocol.manager, connection.PID(), joinedMatchmakeSession)
+	// * Allow game servers to do their own permissions checks
+	if commonProtocol.CanJoinMatchmakeSession != nil {
+		nexError = commonProtocol.CanJoinMatchmakeSession(commonProtocol.manager, connection.PID(), joinedMatchmakeSession)
+	} else {
+		nexError = common_globals.CanJoinMatchmakeSession(commonProtocol.manager, connection.PID(), joinedMatchmakeSession)
+	}
 	if nexError != nil {
 		commonProtocol.manager.Mutex.Unlock()
 		return nil, nexError

--- a/matchmake-extension/join_matchmake_session_with_param.go
+++ b/matchmake-extension/join_matchmake_session_with_param.go
@@ -42,7 +42,12 @@ func (commonProtocol *CommonProtocol) joinMatchmakeSessionWithParam(err error, p
 		return nil, nex.NewError(nex.ResultCodes.RendezVous.InvalidPassword, "change_error")
 	}
 
-	nexError = common_globals.CanJoinMatchmakeSession(commonProtocol.manager, connection.PID(), joinedMatchmakeSession)
+	// * Allow game servers to do their own permissions checks
+	if commonProtocol.CanJoinMatchmakeSession != nil {
+		nexError = commonProtocol.CanJoinMatchmakeSession(commonProtocol.manager, connection.PID(), joinedMatchmakeSession)
+	} else {
+		nexError = common_globals.CanJoinMatchmakeSession(commonProtocol.manager, connection.PID(), joinedMatchmakeSession)
+	}
 	if nexError != nil {
 		commonProtocol.manager.Mutex.Unlock()
 		return nil, nexError

--- a/matchmake-extension/protocol.go
+++ b/matchmake-extension/protocol.go
@@ -14,6 +14,7 @@ type CommonProtocol struct {
 	endpoint                                         nex.EndpointInterface
 	protocol                                         matchmake_extension.Interface
 	manager                                          *common_globals.MatchmakingManager
+	CanJoinMatchmakeSession                          func(manager *common_globals.MatchmakingManager, pid *types.PID, matchmakeSession *match_making_types.MatchmakeSession) *nex.Error
 	CleanupSearchMatchmakeSession                    func(matchmakeSession *match_making_types.MatchmakeSession)
 	CleanupMatchmakeSessionSearchCriterias           func(searchCriterias *types.List[*match_making_types.MatchmakeSessionSearchCriteria])
 	OnAfterOpenParticipation                         func(packet nex.PacketInterface, gid *types.PrimitiveU32)


### PR DESCRIPTION
### Changes:

Adds the option for games to override CanJoinMatchmakeSession with their own version if needed. This is useful for, at least:

- Minecraft: Wii U Edition, which doesn't use NEX ParticipationPolicy at all and instead uses a combination of search attributes and application buffers to determine join eligibility. This is I guess done to allow "Friends of friends" matchmaking on the client; but we'd like to check it serverside too for security reasons.
- Splatoon's Splatfests, which involve matchmaking the second team into a room with `OpenParticipation` false - the current check forbids this. Presumably this is to prevent random individuals matching into a room without a whole team alongside them, which would make the room unplayable (any legit teams would find there aren't enough vacant participants)

I have a [sample of what Minecraft's matchmaking looks like here](https://github.com/PretendoNetwork/minecraft-wiiu/commit/fd75619953903f3cc09520b1d1db67e69e20e3b9). I'm not too sure if you like the design here, since it encourages reaching into the database directly (as I did in the minecraft diff and `database.FindGatheringByID` to get the match participants).

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.