### PR TITLE
feat: Implement MessageDelivery and Messaging protocols

### DIFF
--- a/globals/messaging_globals.go
+++ b/globals/messaging_globals.go
@@ -1,0 +1,147 @@
+package common_globals
+
+import (
+	"database/sql"
+	"unicode/utf8"
+
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+)
+
+// MessagingManager manages messaging communications
+type MessagingManager struct {
+	Database           *sql.DB
+	Endpoint           *nex.PRUDPEndPoint
+
+	MatchmakingManager *MatchmakingManager
+	ValidateMessage    func(message types.DataHolder) (types.UInt64, types.UInt32, *nex.Error)
+	GetMessageHeader   func(message types.DataHolder) (messaging_types.UserMessage, *nex.Error)
+	SetMessageHeader   func(message types.DataHolder, header messaging_types.UserMessage) (types.DataHolder, *nex.Error)
+	ProcessMessage     func(message types.DataHolder, recipientID types.UInt64, recipientType types.UInt32, sendMessage bool) (types.DataHolder, types.List[types.UInt32], types.List[types.PID], *nex.Error)
+}
+
+// ValidateUserMessage checks if a UserMessage is valid, and returns its validity and the recipient information of the message
+func (mm *MessagingManager) ValidateUserMessage(userMessage messaging_types.UserMessage) (types.UInt64, types.UInt32, *nex.Error) {
+	if utf8.RuneCountInString(string(userMessage.StrSubject)) > 256 {
+		return 0, 0, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Message subject is too long")
+	}
+
+	//  Check that the specified recipient is valid
+	recipientID, recipientType := GetUserMessageRecipientData(mm.Endpoint.Server.LibraryVersions.Messaging, userMessage)
+
+	return recipientID, recipientType, nil
+}
+
+// ValidateTextMessage checks if a TextMessage is valid, and returns its validity and the recipient information of the message
+func (mm *MessagingManager) ValidateTextMessage(textMessage messaging_types.TextMessage) (types.UInt64, types.UInt32, *nex.Error) {
+	recipientID, recipientType, nexError := mm.ValidateUserMessage(textMessage.UserMessage)
+	if nexError != nil {
+		return 0, 0, nexError
+	}
+
+	if utf8.RuneCountInString(string(textMessage.StrTextBody)) > 256 {
+		return 0, 0, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Message text body is too long")
+	}
+
+	return recipientID, recipientType, nil
+}
+
+// ValidateBinaryMessage checks if a BinaryMessage is valid, and returns its validity and the recipient information of the message
+func (mm *MessagingManager) ValidateBinaryMessage(binaryMessage messaging_types.BinaryMessage) (types.UInt64, types.UInt32, *nex.Error) {
+	recipientID, recipientType, nexError := mm.ValidateUserMessage(binaryMessage.UserMessage)
+	if nexError != nil {
+		return 0, 0, nexError
+	}
+
+	if len(binaryMessage.BinaryBody) > 512 {
+		return 0, 0, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Message binary body is too long")
+	}
+
+	return recipientID, recipientType, nil
+}
+
+// DefaultValidateMessage is the default handler of MessagingManager to validate an input message holder
+func (mm *MessagingManager) DefaultValidateMessage(message types.DataHolder) (types.UInt64, types.UInt32, *nex.Error) {
+	messageObjectID := message.Object.ObjectID()
+	if messageObjectID.Equals(types.NewString("TextMessage")) {
+		return mm.ValidateTextMessage(message.Object.(messaging_types.TextMessage))
+	} else if messageObjectID.Equals(types.NewString("BinaryMessage")) {
+		return mm.ValidateBinaryMessage(message.Object.(messaging_types.BinaryMessage))
+	}
+
+	return 0, 0, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Invalid data holder object ID")
+}
+
+// DefaultGetMessageHeader is the default handler for GetMessageHeader
+func (mm *MessagingManager) DefaultGetMessageHeader(message types.DataHolder) (messaging_types.UserMessage, *nex.Error) {
+	messageObjectID := message.Object.ObjectID()
+	if messageObjectID.Equals(types.NewString("TextMessage")) {
+		return message.Object.(messaging_types.TextMessage).UserMessage, nil
+	} else if messageObjectID.Equals(types.NewString("BinaryMessage")) {
+		return message.Object.(messaging_types.BinaryMessage).UserMessage, nil
+	}
+
+	return messaging_types.UserMessage{}, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Invalid data holder object ID")
+}
+
+// DefaultSetMessageHeader is the default handler for SetMessageHeader
+func (mm *MessagingManager) DefaultSetMessageHeader(message types.DataHolder, header messaging_types.UserMessage) (types.DataHolder, *nex.Error) {
+	messageObjectID := message.Object.ObjectID()
+	if messageObjectID.Equals(types.NewString("TextMessage")) {
+		textMessage := message.Object.(messaging_types.TextMessage)
+		textMessage.UserMessage = header
+		message.Object = textMessage
+	} else if messageObjectID.Equals(types.NewString("BinaryMessage")) {
+		binaryMessage := message.Object.(messaging_types.BinaryMessage)
+		binaryMessage.UserMessage = header
+		message.Object = binaryMessage
+	} else {
+		return message, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Invalid data holder object ID")
+	}
+
+	return message, nil
+}
+
+// PrepareMessage populates the required missing fields of the message
+func (mm *MessagingManager) PrepareMessage(senderPID types.PID, message types.DataHolder) (types.DataHolder, *nex.Error) {
+	messageHeader, nexError := mm.GetMessageHeader(message)
+	if nexError != nil {
+		return message, nexError
+	}
+
+	senderAccount, nexError := mm.Endpoint.AccountDetailsByPID(senderPID)
+	if nexError != nil {
+		return message, nexError
+	}
+
+	// * The message subject is capped to 60 characters
+	if utf8.RuneCountInString(string(messageHeader.StrSubject)) > 60 {
+		messageHeader.StrSubject = types.String(ResizeString(string(messageHeader.StrSubject), 60))
+	}
+
+	messageHeader.PIDSender = senderAccount.PID
+	messageHeader.StrSender = types.String(senderAccount.Username)
+	messageHeader.Receptiontime = messageHeader.Receptiontime.Now()
+
+	message, nexError = mm.SetMessageHeader(message, messageHeader)
+	if nexError != nil {
+		return message, nexError
+	}
+
+	return message, nil
+}
+
+// NewMessagingManager returns a new MessagingManager
+func NewMessagingManager(endpoint *nex.PRUDPEndPoint, db *sql.DB) *MessagingManager {
+	mm := &MessagingManager{
+		Endpoint: endpoint,
+		Database: db,
+	}
+
+	mm.ValidateMessage = mm.DefaultValidateMessage
+	mm.GetMessageHeader = mm.DefaultGetMessageHeader
+	mm.SetMessageHeader = mm.DefaultSetMessageHeader
+
+	return mm
+}

--- a/globals/messaging_globals.go
+++ b/globals/messaging_globals.go
@@ -20,6 +20,7 @@ type MessagingManager struct {
 	SetMessageHeader         func(message types.DataHolder, header messaging_types.UserMessage) (types.DataHolder, *nex.Error)
 	ProcessMessage           func(manager *MessagingManager, message types.DataHolder, recipientIDs types.List[types.UInt64], recipientType types.UInt32, sendMessage bool) (types.DataHolder, types.List[types.UInt32], types.List[types.PID], *nex.Error)
 	ValidateMessageRecipient func(manager *MessagingManager, pid types.PID, recipientID types.UInt64, recipientType types.UInt32) bool
+	RetrieveDetailedMessage  func(manager *MessagingManager, messageHeader messaging_types.UserMessage, messageType string) (types.DataHolder, *nex.Error)
 }
 
 // ValidateUserMessage checks if a UserMessage is valid, and returns its validity and the recipient information of the message

--- a/globals/messaging_globals.go
+++ b/globals/messaging_globals.go
@@ -11,14 +11,15 @@ import (
 
 // MessagingManager manages messaging communications
 type MessagingManager struct {
-	Database           *sql.DB
-	Endpoint           *nex.PRUDPEndPoint
+	Database                 *sql.DB
+	Endpoint                 *nex.PRUDPEndPoint
 
-	MatchmakingManager *MatchmakingManager
-	ValidateMessage    func(message types.DataHolder) (types.UInt64, types.UInt32, *nex.Error)
-	GetMessageHeader   func(message types.DataHolder) (messaging_types.UserMessage, *nex.Error)
-	SetMessageHeader   func(message types.DataHolder, header messaging_types.UserMessage) (types.DataHolder, *nex.Error)
-	ProcessMessage     func(manager *MessagingManager, message types.DataHolder, recipientIDs types.List[types.UInt64], recipientType types.UInt32, sendMessage bool) (types.DataHolder, types.List[types.UInt32], types.List[types.PID], *nex.Error)
+	MatchmakingManager       *MatchmakingManager
+	ValidateMessage          func(message types.DataHolder) (types.UInt64, types.UInt32, *nex.Error)
+	GetMessageHeader         func(message types.DataHolder) (messaging_types.UserMessage, *nex.Error)
+	SetMessageHeader         func(message types.DataHolder, header messaging_types.UserMessage) (types.DataHolder, *nex.Error)
+	ProcessMessage           func(manager *MessagingManager, message types.DataHolder, recipientIDs types.List[types.UInt64], recipientType types.UInt32, sendMessage bool) (types.DataHolder, types.List[types.UInt32], types.List[types.PID], *nex.Error)
+	ValidateMessageRecipient func(manager *MessagingManager, pid types.PID, recipientID types.UInt64, recipientType types.UInt32) bool
 }
 
 // ValidateUserMessage checks if a UserMessage is valid, and returns its validity and the recipient information of the message

--- a/globals/messaging_globals.go
+++ b/globals/messaging_globals.go
@@ -18,7 +18,7 @@ type MessagingManager struct {
 	ValidateMessage    func(message types.DataHolder) (types.UInt64, types.UInt32, *nex.Error)
 	GetMessageHeader   func(message types.DataHolder) (messaging_types.UserMessage, *nex.Error)
 	SetMessageHeader   func(message types.DataHolder, header messaging_types.UserMessage) (types.DataHolder, *nex.Error)
-	ProcessMessage     func(message types.DataHolder, recipientID types.UInt64, recipientType types.UInt32, sendMessage bool) (types.DataHolder, types.List[types.UInt32], types.List[types.PID], *nex.Error)
+	ProcessMessage     func(manager *MessagingManager, message types.DataHolder, recipientIDs types.List[types.UInt64], recipientType types.UInt32, sendMessage bool) (types.DataHolder, types.List[types.UInt32], types.List[types.PID], *nex.Error)
 }
 
 // ValidateUserMessage checks if a UserMessage is valid, and returns its validity and the recipient information of the message
@@ -27,9 +27,7 @@ func (mm *MessagingManager) ValidateUserMessage(userMessage messaging_types.User
 		return 0, 0, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Message subject is too long")
 	}
 
-	//  Check that the specified recipient is valid
 	recipientID, recipientType := GetUserMessageRecipientData(mm.Endpoint.Server.LibraryVersions.Messaging, userMessage)
-
 	return recipientID, recipientType, nil
 }
 

--- a/globals/utils.go
+++ b/globals/utils.go
@@ -188,6 +188,23 @@ func SetUserMessageRecipientData(libraryVersion *nex.LibraryVersion, userMessage
 	return userMessage
 }
 
+// GetMessageRecipientData returns the recipient ID and the recipient type of a message recipient
+func GetMessageRecipientData(libraryVersion *nex.LibraryVersion, recipient messaging_types.MessageRecipient) (types.UInt64, types.UInt32) {
+	if libraryVersion.GreaterOrEqual("4.0.0") {
+		switch recipient.UIRecipientType {
+		case 1:
+			return types.UInt64(recipient.PrincipalID), recipient.UIRecipientType
+		case 2:
+			return types.UInt64(recipient.GatheringID), recipient.UIRecipientType
+		default:
+			Logger.Errorf("Invalid recipient type %d", recipient.UIRecipientType)
+			return 0, recipient.UIRecipientType // * Unknown
+		}
+	}
+
+	return types.UInt64(recipient.IDRecipient), recipient.UIRecipientType
+}
+
 // SendNotificationEvent sends a notification event to the specified targets
 func SendNotificationEvent(endpoint *nex.PRUDPEndPoint, event notifications_types.NotificationEvent, targets []uint64) {
 	server := endpoint.Server

--- a/globals/utils.go
+++ b/globals/utils.go
@@ -159,11 +159,33 @@ func GetUserMessageRecipientData(libraryVersion *nex.LibraryVersion, userMessage
 		case 2:
 			return types.UInt64(userMessage.MessageRecipient.GatheringID), userMessage.MessageRecipient.UIRecipientType
 		default:
+			Logger.Errorf("Invalid recipient type %d", userMessage.MessageRecipient.UIRecipientType)
 			return 0, userMessage.MessageRecipient.UIRecipientType // * Unknown
 		}
 	}
 
 	return types.UInt64(userMessage.IDRecipient), userMessage.UIRecipientType
+}
+
+// SetUserMessageRecipientData sets the recipient ID and the recipient type of a message
+func SetUserMessageRecipientData(libraryVersion *nex.LibraryVersion, userMessage messaging_types.UserMessage, recipientID types.UInt64, recipientType types.UInt32) messaging_types.UserMessage {
+	if libraryVersion.GreaterOrEqual("4.0.0") {
+		switch recipientType {
+		case 1:
+			userMessage.MessageRecipient.UIRecipientType = recipientType
+			userMessage.MessageRecipient.PrincipalID = types.PID(recipientID)
+		case 2:
+			userMessage.MessageRecipient.UIRecipientType = recipientType
+			userMessage.MessageRecipient.GatheringID = types.UInt32(recipientID)
+		default:
+			Logger.Errorf("Invalid recipient type %d", recipientType)
+		}
+	} else {
+		userMessage.IDRecipient = types.UInt32(recipientID)
+		userMessage.UIRecipientType = recipientType
+	}
+
+	return userMessage
 }
 
 // SendNotificationEvent sends a notification event to the specified targets

--- a/message-delivery/deliver_message.go
+++ b/message-delivery/deliver_message.go
@@ -1,0 +1,49 @@
+package message_delivery
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+
+	message_delivery "github.com/PretendoNetwork/nex-protocols-go/v2/message-delivery"
+)
+
+func (commonProtocol *CommonProtocol) deliverMessage(err error, packet nex.PacketInterface, callID uint32, oUserMessage types.DataHolder) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, err.Error())
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+
+	// NOTE - This method will silently fail on any errors
+	rmcResponse := nex.NewRMCSuccess(endpoint, nil)
+	rmcResponse.ProtocolID = message_delivery.ProtocolID
+	rmcResponse.MethodID = message_delivery.MethodDeliverMessage
+	rmcResponse.CallID = callID
+
+	recipientID, recipientType, nexError := commonProtocol.manager.ValidateMessage(oUserMessage)
+	if nexError != nil {
+		common_globals.Logger.Error(nexError.Error())
+		return rmcResponse, nil
+	}
+
+	oUserMessage, nexError = commonProtocol.manager.PrepareMessage(connection.PID(), oUserMessage)
+	if nexError != nil {
+		common_globals.Logger.Error(nexError.Error())
+		return rmcResponse, nil
+	}
+
+	_, _, _, nexError = commonProtocol.manager.ProcessMessage(oUserMessage, recipientID, recipientType, true)
+	if nexError != nil {
+		common_globals.Logger.Error(nexError.Error())
+		return rmcResponse, nil
+	}
+
+	if commonProtocol.OnAfterDeliverMessage != nil {
+		go commonProtocol.OnAfterDeliverMessage(packet, oUserMessage)
+	}
+
+	return rmcResponse, nil
+}

--- a/message-delivery/deliver_message_multi_target.go
+++ b/message-delivery/deliver_message_multi_target.go
@@ -23,6 +23,12 @@ func (commonProtocol *CommonProtocol) deliverMessageMultiTarget(err error, packe
 	rmcResponse.MethodID = message_delivery.MethodDeliverMessageMultiTarget
 	rmcResponse.CallID = callID
 
+	// * Only allow up to 100 targets, based on the maximum amount of friends allowed
+	if len(lstTarget) > 100 {
+		common_globals.Logger.Error("Message has over 100 targets")
+		return rmcResponse, nil
+	}
+
 	_, _, nexError := commonProtocol.manager.ValidateMessage(oUserMessage)
 	if nexError != nil {
 		common_globals.Logger.Error(nexError.Error())

--- a/message-delivery/protocol.go
+++ b/message-delivery/protocol.go
@@ -1,0 +1,83 @@
+package message_delivery
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	message_delivery "github.com/PretendoNetwork/nex-protocols-go/v2/message-delivery"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	messaging_database "github.com/PretendoNetwork/nex-protocols-common-go/v2/messaging/database"
+)
+
+type CommonProtocol struct {
+	endpoint              nex.EndpointInterface
+	protocol              message_delivery.Interface
+	manager               *common_globals.MessagingManager
+	OnAfterDeliverMessage func(packet nex.PacketInterface, oUserMessage types.DataHolder)
+}
+
+// SetManager defines the messaging manager to be used by the common protocol
+func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.MessagingManager) {
+	var err error
+
+	commonProtocol.manager = manager
+
+	if manager.ProcessMessage == nil {
+		manager.ProcessMessage = func(message types.DataHolder, recipientID types.UInt64, recipientType types.UInt32, sendMessage bool) (types.DataHolder, types.List[types.UInt32], types.List[types.PID], *nex.Error) {
+			return messaging_database.ProcessMessage(manager, message, recipientID, recipientType, sendMessage)
+		}
+	}
+
+	_, err = manager.Database.Exec(`CREATE SCHEMA IF NOT EXISTS messaging`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.instant_messages (
+		id bigserial PRIMARY KEY,
+		recipient_id numeric(20),
+		recipient_type numeric(10),
+		parent_id bigint,
+		sender_pid numeric(20),
+		reception_time timestamp,
+		lifetime numeric(10),
+		flags bigint,
+		subject text,
+		sender text,
+		type text NOT NULL DEFAULT ''
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.instant_text_messages (
+		id bigint PRIMARY KEY REFERENCES messaging.instant_messages(id),
+		body text
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.instant_binary_messages (
+		id bigint PRIMARY KEY REFERENCES messaging.instant_messages(id),
+		body bytea
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+}
+
+// NewCommonProtocol returns a new CommonProtocol
+func NewCommonProtocol(protocol message_delivery.Interface) *CommonProtocol {
+	commonProtocol := &CommonProtocol{
+		endpoint: protocol.Endpoint(),
+		protocol: protocol,
+	}
+
+	protocol.SetHandlerDeliverMessage(commonProtocol.deliverMessage)
+
+	return commonProtocol
+}

--- a/message-delivery/protocol.go
+++ b/message-delivery/protocol.go
@@ -27,6 +27,10 @@ func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.Messagi
 		manager.ValidateMessageRecipient = messaging_database.ValidateMessageRecipient
 	}
 
+	if manager.RetrieveDetailedMessage == nil {
+		manager.RetrieveDetailedMessage = messaging_database.RetrieveDetailedMessage
+	}
+
 	_, err = manager.Database.Exec(`CREATE SCHEMA IF NOT EXISTS messaging`)
 	if err != nil {
 		common_globals.Logger.Error(err.Error())

--- a/message-delivery/protocol.go
+++ b/message-delivery/protocol.go
@@ -64,6 +64,43 @@ func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.Messagi
 		common_globals.Logger.Error(err.Error())
 		return
 	}
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.messages (
+		id bigserial PRIMARY KEY,
+		recipient_id numeric(20),
+		recipient_type numeric(10),
+		parent_id bigint,
+		sender_pid numeric(20),
+		reception_time timestamp,
+		lifetime numeric(10),
+		flags bigint,
+		subject text,
+		sender text,
+		type text NOT NULL DEFAULT '',
+		deleted boolean NOT NULL DEFAULT false
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.text_messages (
+		id bigint PRIMARY KEY REFERENCES messaging.messages(id),
+		body text
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.binary_messages (
+		id bigint PRIMARY KEY REFERENCES messaging.messages(id),
+		body bytea
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
 }
 
 // NewCommonProtocol returns a new CommonProtocol

--- a/message-delivery/protocol.go
+++ b/message-delivery/protocol.go
@@ -23,6 +23,10 @@ func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.Messagi
 		manager.ProcessMessage = messaging_database.ProcessMessage
 	}
 
+	if manager.ValidateMessageRecipient == nil {
+		manager.ValidateMessageRecipient = messaging_database.ValidateMessageRecipient
+	}
+
 	_, err = manager.Database.Exec(`CREATE SCHEMA IF NOT EXISTS messaging`)
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
@@ -68,11 +72,11 @@ func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.Messagi
 	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.messages (
 		id bigserial PRIMARY KEY,
 		recipient_id numeric(20),
-		recipient_type numeric(10),
+		recipient_type bigint,
 		parent_id bigint,
 		sender_pid numeric(20),
 		reception_time timestamp,
-		lifetime numeric(10),
+		lifetime bigint,
 		flags bigint,
 		subject text,
 		sender text,

--- a/messaging/database/delete_all_messages.go
+++ b/messaging/database/delete_all_messages.go
@@ -1,0 +1,31 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// DeleteAllMessages deletes all messages for the given recipient
+func DeleteAllMessages(manager *common_globals.MessagingManager, recipientID types.UInt64, recipientType types.UInt32) (types.UInt32, *nex.Error) {
+	var err error
+
+	result, err := manager.Database.Exec(`UPDATE FROM messaging.messages SET deleted = true WHERE
+		recipient_id = $1 AND
+		recipient_type = $2 AND
+		reception_time + lifetime * INTERVAL '1 second' > NOW() AND
+		read IS NOT TRUE AND
+		deleted IS NOT TRUE
+	`, recipientID, recipientType)
+	if err != nil {
+		return 0, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	uiNbDeletedMessages, err := result.RowsAffected()
+	if err != nil {
+		return 0, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	return types.UInt32(uiNbDeletedMessages), nil
+}

--- a/messaging/database/delete_messages.go
+++ b/messaging/database/delete_messages.go
@@ -1,0 +1,27 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// DeleteMessages deletes the given messages for the given recipient
+func DeleteMessages(manager *common_globals.MessagingManager, recipientID types.UInt64, recipientType types.UInt32, lstMessagesToDelete types.List[types.UInt32]) *nex.Error {
+	var err error
+
+	_, err = manager.Database.Exec(`UPDATE FROM messaging.messages SET deleted = true WHERE
+		id = ANY($1) AND
+		recipient_id = $2 AND
+		recipient_type = $3 AND
+		reception_time + lifetime * INTERVAL '1 second' > NOW() AND
+		read IS NOT TRUE AND
+		deleted IS NOT TRUE
+	`, lstMessagesToDelete, recipientID, recipientType)
+	if err != nil {
+		return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	return nil
+}

--- a/messaging/database/get_binary_message_from_user_message.go
+++ b/messaging/database/get_binary_message_from_user_message.go
@@ -1,0 +1,23 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// GetBinaryMessageFromUserMessage gets the binary body for a given user message
+func GetBinaryMessageFromUserMessage(manager *common_globals.MessagingManager, messageHeader messaging_types.UserMessage) (messaging_types.BinaryMessage, *nex.Error) {
+	var binaryMessage messaging_types.BinaryMessage
+	var err error
+
+	err = manager.Database.QueryRow(`SELECT body FROM messaging.binary_messages WHERE id = $1`, messageHeader.UIID).Scan(&binaryMessage.BinaryBody)
+	if err != nil {
+		return binaryMessage, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	binaryMessage.UserMessage = messageHeader
+
+	return binaryMessage, nil
+}

--- a/messaging/database/get_messages_headers.go
+++ b/messaging/database/get_messages_headers.go
@@ -8,7 +8,7 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
 )
 
-// GetMessagesHeaders gets the number of messages available for the given recipient
+// GetMessagesHeaders gets the message headers available for the given recipient
 func GetMessagesHeaders(manager *common_globals.MessagingManager, recipientID types.UInt64, recipientType types.UInt32, resultRange types.ResultRange) (types.List[messaging_types.UserMessage], *nex.Error) {
 	lstMsgHeaders := make(types.List[messaging_types.UserMessage], 0, resultRange.Length)
 

--- a/messaging/database/get_messages_headers.go
+++ b/messaging/database/get_messages_headers.go
@@ -1,0 +1,69 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// GetMessagesHeaders gets the number of messages available for the given recipient
+func GetMessagesHeaders(manager *common_globals.MessagingManager, recipientID types.UInt64, recipientType types.UInt32, resultRange types.ResultRange) (types.List[messaging_types.UserMessage], *nex.Error) {
+	lstMsgHeaders := make(types.List[messaging_types.UserMessage], 0, resultRange.Length)
+
+	rows, err := manager.Database.Query(`SELECT (
+		id,
+		recipient_id,
+		recipient_type,
+		parent_id,
+		sender_pid,
+		reception_time,
+		lifetime,
+		flags,
+		subject,
+		sender,
+	) FROM messaging.messages WHERE
+		recipient_id = $1 AND
+		recipient_type = $2 AND
+		reception_time + lifetime * INTERVAL '1 second' > NOW() AND
+		read IS NOT TRUE AND
+		deleted IS NOT TRUE
+		OFFSET $3
+		LIMIT $4
+	`, recipientID, recipientType, resultRange.Offset, resultRange.Length)
+	if err != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	defer rows.Close()
+
+	libraryVersion := manager.Endpoint.Server.LibraryVersions.Messaging
+
+	for rows.Next() {
+		var messageHeader messaging_types.UserMessage
+		var recipientID types.UInt64
+		var recipientType types.UInt32
+
+		err = rows.Scan(
+			&messageHeader.UIID,
+			&recipientID,
+			&recipientType,
+			&messageHeader.UIParentID,
+			&messageHeader.PIDSender,
+			&messageHeader.Receptiontime,
+			&messageHeader.UILifeTime,
+			&messageHeader.UIFlags,
+			&messageHeader.StrSubject,
+			&messageHeader.StrSender,
+		)
+		if err != nil {
+			return nil, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+		}
+
+		messageHeader = common_globals.SetUserMessageRecipientData(libraryVersion, messageHeader, recipientID, recipientType)
+		lstMsgHeaders = append(lstMsgHeaders, messageHeader)
+	}
+
+	return lstMsgHeaders, nil
+}

--- a/messaging/database/get_number_of_messages.go
+++ b/messaging/database/get_number_of_messages.go
@@ -1,0 +1,27 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// GetNumberOfMessages gets the number of messages available for the given recipient
+func GetNumberOfMessages(manager *common_globals.MessagingManager, recipientID types.UInt64, recipientType types.UInt32) (types.UInt32, *nex.Error) {
+	var err error
+	var uiNbMessages types.UInt32
+
+	err = manager.Database.QueryRow(`SELECT COUNT(id) FROM messaging.messages WHERE
+		recipient_id = $1 AND
+		recipient_type = $2 AND
+		reception_time + lifetime * INTERVAL '1 second' > NOW() AND
+		read IS NOT TRUE AND
+		deleted IS NOT TRUE
+	`, recipientID, recipientType).Scan(&uiNbMessages)
+	if err != nil {
+		return uiNbMessages, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	return uiNbMessages, nil
+}

--- a/messaging/database/get_text_message_from_user_message.go
+++ b/messaging/database/get_text_message_from_user_message.go
@@ -1,0 +1,23 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// GetTextMessageFromUserMessage gets the text body for a given user message
+func GetTextMessageFromUserMessage(manager *common_globals.MessagingManager, messageHeader messaging_types.UserMessage) (messaging_types.TextMessage, *nex.Error) {
+	var textMessage messaging_types.TextMessage
+	var err error
+
+	err = manager.Database.QueryRow(`SELECT body FROM messaging.text_messages WHERE id = $1`, messageHeader.UIID).Scan(&textMessage.StrTextBody)
+	if err != nil {
+		return textMessage, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	textMessage.UserMessage = messageHeader
+
+	return textMessage, nil
+}

--- a/messaging/database/insert_binary_message.go
+++ b/messaging/database/insert_binary_message.go
@@ -11,18 +11,46 @@ import (
 func InsertBinaryMessage(manager *common_globals.MessagingManager, message messaging_types.BinaryMessage, recipientID types.UInt64, recipientType types.UInt32) *nex.Error {
 	var err error
 
-	messageID, nexError := InsertMessage(manager, message.UserMessage, recipientID, recipientType, "BinaryMessage")
-	if nexError != nil {
-		return nexError
-	}
-
-	_, err = manager.Database.Exec(`INSERT INTO messaging.binary_messages (
+	_, err = manager.Database.Exec(`WITH message_id AS (INSERT INTO messaging.messages (
+		recipient_id,
+		recipient_type,
+		parent_id,
+		sender_pid,
+		reception_time,
+		lifetime,
+		flags,
+		subject,
+		sender,
+		type
+	) VALUES (
+		$1,
+		$2,
+		$3,
+		$4,
+		$5,
+		$6,
+		$7,
+		$8,
+		$9,
+		'BinaryMessage'
+	) RETURNING id) INSERT INTO messaging.binary_messages (
 		id,
 		body
 	) VALUES (
-		$1,
-		$2
-	)`, messageID, message.BinaryBody)
+		(SELECT id FROM message_id),
+		$10
+	)`,
+		recipientID,
+		recipientType,
+		message.UserMessage.UIParentID,
+		message.UserMessage.PIDSender,
+		message.UserMessage.Receptiontime,
+		message.UserMessage.UILifeTime,
+		message.UserMessage.UIFlags,
+		message.UserMessage.StrSubject,
+		message.UserMessage.StrSender,
+		message.BinaryBody,
+	)
 	if err != nil {
 		return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
 	}

--- a/messaging/database/insert_binary_message.go
+++ b/messaging/database/insert_binary_message.go
@@ -1,0 +1,31 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// InsertBinaryMessage inserts a new binary message into the database
+func InsertBinaryMessage(manager *common_globals.MessagingManager, message messaging_types.BinaryMessage, recipientID types.UInt64, recipientType types.UInt32) *nex.Error {
+	var err error
+
+	messageID, nexError := InsertMessage(manager, message.UserMessage, recipientID, recipientType, "BinaryMessage")
+	if nexError != nil {
+		return nexError
+	}
+
+	_, err = manager.Database.Exec(`INSERT INTO messaging.binary_messages (
+		id,
+		body
+	) VALUES (
+		$1,
+		$2
+	)`, messageID, message.BinaryBody)
+	if err != nil {
+		return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	return nil
+}

--- a/messaging/database/insert_instant_binary_message.go
+++ b/messaging/database/insert_instant_binary_message.go
@@ -1,0 +1,31 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// InsertInstantBinaryMessage inserts a new instant binary message into the database
+func InsertInstantBinaryMessage(manager *common_globals.MessagingManager, message messaging_types.BinaryMessage, recipientID types.UInt64, recipientType types.UInt32) *nex.Error {
+	var err error
+
+	messageID, nexError := InsertInstantMessage(manager, message.UserMessage, recipientID, recipientType, "BinaryMessage")
+	if nexError != nil {
+		return nexError
+	}
+
+	_, err = manager.Database.Exec(`INSERT INTO messaging.instant_binary_messages (
+		id,
+		body
+	) VALUES (
+		$1,
+		$2
+	)`, messageID, message.BinaryBody)
+	if err != nil {
+		return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	return nil
+}

--- a/messaging/database/insert_instant_binary_message.go
+++ b/messaging/database/insert_instant_binary_message.go
@@ -11,18 +11,46 @@ import (
 func InsertInstantBinaryMessage(manager *common_globals.MessagingManager, message messaging_types.BinaryMessage, recipientID types.UInt64, recipientType types.UInt32) *nex.Error {
 	var err error
 
-	messageID, nexError := InsertInstantMessage(manager, message.UserMessage, recipientID, recipientType, "BinaryMessage")
-	if nexError != nil {
-		return nexError
-	}
-
-	_, err = manager.Database.Exec(`INSERT INTO messaging.instant_binary_messages (
+	_, err = manager.Database.Exec(`WITH message_id AS (INSERT INTO messaging.instant_messages (
+		recipient_id,
+		recipient_type,
+		parent_id,
+		sender_pid,
+		reception_time,
+		lifetime,
+		flags,
+		subject,
+		sender,
+		type
+	) VALUES (
+		$1,
+		$2,
+		$3,
+		$4,
+		$5,
+		$6,
+		$7,
+		$8,
+		$9,
+		'BinaryMessage'
+	) RETURNING id) INSERT INTO messaging.instant_binary_messages (
 		id,
 		body
 	) VALUES (
-		$1,
-		$2
-	)`, messageID, message.BinaryBody)
+		(SELECT id FROM message_id),
+		$10
+	)`,
+		recipientID,
+		recipientType,
+		message.UserMessage.UIParentID,
+		message.UserMessage.PIDSender,
+		message.UserMessage.Receptiontime,
+		message.UserMessage.UILifeTime,
+		message.UserMessage.UIFlags,
+		message.UserMessage.StrSubject,
+		message.UserMessage.StrSender,
+		message.BinaryBody,
+	)
 	if err != nil {
 		return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
 	}

--- a/messaging/database/insert_instant_message.go
+++ b/messaging/database/insert_instant_message.go
@@ -1,0 +1,54 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// InsertInstantMessage inserts a new instant message into the database
+func InsertInstantMessage(manager *common_globals.MessagingManager, message messaging_types.UserMessage, recipientID types.UInt64, recipientType types.UInt32, messageType string) (uint32, *nex.Error) {
+	var err error
+	var messageID uint32
+
+	err = manager.Database.QueryRow(`INSERT INTO messaging.instant_messages (
+		recipient_id,
+		recipient_type,
+		parent_id,
+		sender_pid,
+		reception_time,
+		lifetime,
+		flags,
+		subject,
+		sender,
+		type
+	) VALUES (
+		$1,
+		$2,
+		$3,
+		$4,
+		$5,
+		$6,
+		$7,
+		$8,
+		$9,
+		$10
+	) RETURNING id`,
+		recipientID,
+		recipientType,
+		message.UIParentID,
+		message.PIDSender,
+		message.Receptiontime,
+		message.UILifeTime,
+		message.UIFlags,
+		message.StrSubject,
+		message.StrSender,
+		messageType,
+	).Scan(&messageID)
+	if err != nil {
+		return 0, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	return messageID, nil
+}

--- a/messaging/database/insert_instant_text_message.go
+++ b/messaging/database/insert_instant_text_message.go
@@ -1,0 +1,31 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// InsertInstantTextMessage inserts a new instant text message into the database
+func InsertInstantTextMessage(manager *common_globals.MessagingManager, message messaging_types.TextMessage, recipientID types.UInt64, recipientType types.UInt32) *nex.Error {
+	var err error
+
+	messageID, nexError := InsertInstantMessage(manager, message.UserMessage, recipientID, recipientType, "TextMessage")
+	if nexError != nil {
+		return nexError
+	}
+
+	_, err = manager.Database.Exec(`INSERT INTO messaging.instant_text_messages (
+		id,
+		body
+	) VALUES (
+		$1,
+		$2
+	)`, messageID, message.StrTextBody)
+	if err != nil {
+		return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	return nil
+}

--- a/messaging/database/insert_instant_text_message.go
+++ b/messaging/database/insert_instant_text_message.go
@@ -11,18 +11,46 @@ import (
 func InsertInstantTextMessage(manager *common_globals.MessagingManager, message messaging_types.TextMessage, recipientID types.UInt64, recipientType types.UInt32) *nex.Error {
 	var err error
 
-	messageID, nexError := InsertInstantMessage(manager, message.UserMessage, recipientID, recipientType, "TextMessage")
-	if nexError != nil {
-		return nexError
-	}
-
-	_, err = manager.Database.Exec(`INSERT INTO messaging.instant_text_messages (
+	_, err = manager.Database.Exec(`WITH message_id AS (INSERT INTO messaging.instant_messages (
+		recipient_id,
+		recipient_type,
+		parent_id,
+		sender_pid,
+		reception_time,
+		lifetime,
+		flags,
+		subject,
+		sender,
+		type
+	) VALUES (
+		$1,
+		$2,
+		$3,
+		$4,
+		$5,
+		$6,
+		$7,
+		$8,
+		$9,
+		'TextMessage'
+	) RETURNING id) INSERT INTO messaging.instant_text_messages (
 		id,
 		body
 	) VALUES (
-		$1,
-		$2
-	)`, messageID, message.StrTextBody)
+		(SELECT id FROM message_id),
+		$10
+	)`,
+		recipientID,
+		recipientType,
+		message.UserMessage.UIParentID,
+		message.UserMessage.PIDSender,
+		message.UserMessage.Receptiontime,
+		message.UserMessage.UILifeTime,
+		message.UserMessage.UIFlags,
+		message.UserMessage.StrSubject,
+		message.UserMessage.StrSender,
+		message.StrTextBody,
+	)
 	if err != nil {
 		return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
 	}

--- a/messaging/database/insert_message.go
+++ b/messaging/database/insert_message.go
@@ -1,0 +1,54 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// InsertMessage inserts a new message into the database
+func InsertMessage(manager *common_globals.MessagingManager, message messaging_types.UserMessage, recipientID types.UInt64, recipientType types.UInt32, messageType string) (uint32, *nex.Error) {
+	var err error
+	var messageID uint32
+
+	err = manager.Database.QueryRow(`INSERT INTO messaging.messages (
+		recipient_id,
+		recipient_type,
+		parent_id,
+		sender_pid,
+		reception_time,
+		lifetime,
+		flags,
+		subject,
+		sender,
+		type
+	) VALUES (
+		$1,
+		$2,
+		$3,
+		$4,
+		$5,
+		$6,
+		$7,
+		$8,
+		$9,
+		$10
+	) RETURNING id`,
+		recipientID,
+		recipientType,
+		message.UIParentID,
+		message.PIDSender,
+		message.Receptiontime,
+		message.UILifeTime,
+		message.UIFlags,
+		message.StrSubject,
+		message.StrSender,
+		messageType,
+	).Scan(&messageID)
+	if err != nil {
+		return 0, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	return messageID, nil
+}

--- a/messaging/database/insert_text_message.go
+++ b/messaging/database/insert_text_message.go
@@ -11,18 +11,46 @@ import (
 func InsertTextMessage(manager *common_globals.MessagingManager, message messaging_types.TextMessage, recipientID types.UInt64, recipientType types.UInt32) *nex.Error {
 	var err error
 
-	messageID, nexError := InsertInstantMessage(manager, message.UserMessage, recipientID, recipientType, "TextMessage")
-	if nexError != nil {
-		return nexError
-	}
-
-	_, err = manager.Database.Exec(`INSERT INTO messaging.text_messages (
+	_, err = manager.Database.Exec(`WITH message_id AS (INSERT INTO messaging.messages (
+		recipient_id,
+		recipient_type,
+		parent_id,
+		sender_pid,
+		reception_time,
+		lifetime,
+		flags,
+		subject,
+		sender,
+		type
+	) VALUES (
+		$1,
+		$2,
+		$3,
+		$4,
+		$5,
+		$6,
+		$7,
+		$8,
+		$9,
+		'TextMessage'
+	) RETURNING id) INSERT INTO messaging.text_messages (
 		id,
 		body
 	) VALUES (
-		$1,
-		$2
-	)`, messageID, message.StrTextBody)
+		(SELECT id FROM message_id),
+		$10
+	)`,
+		recipientID,
+		recipientType,
+		message.UserMessage.UIParentID,
+		message.UserMessage.PIDSender,
+		message.UserMessage.Receptiontime,
+		message.UserMessage.UILifeTime,
+		message.UserMessage.UIFlags,
+		message.UserMessage.StrSubject,
+		message.UserMessage.StrSender,
+		message.StrTextBody,
+	)
 	if err != nil {
 		return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
 	}

--- a/messaging/database/insert_text_message.go
+++ b/messaging/database/insert_text_message.go
@@ -1,0 +1,31 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// InsertTextMessage inserts a new text message into the database
+func InsertTextMessage(manager *common_globals.MessagingManager, message messaging_types.TextMessage, recipientID types.UInt64, recipientType types.UInt32) *nex.Error {
+	var err error
+
+	messageID, nexError := InsertInstantMessage(manager, message.UserMessage, recipientID, recipientType, "TextMessage")
+	if nexError != nil {
+		return nexError
+	}
+
+	_, err = manager.Database.Exec(`INSERT INTO messaging.text_messages (
+		id,
+		body
+	) VALUES (
+		$1,
+		$2
+	)`, messageID, message.StrTextBody)
+	if err != nil {
+		return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	return nil
+}

--- a/messaging/database/process_message.go
+++ b/messaging/database/process_message.go
@@ -1,0 +1,98 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	match_making_database "github.com/PretendoNetwork/nex-protocols-common-go/v2/match-making/database"
+)
+
+// ProcessMessage delivers the given message and stores it in the server
+func ProcessMessage(manager *common_globals.MessagingManager, message types.DataHolder, recipientID types.UInt64, recipientType types.UInt32, sendMessage bool) (types.DataHolder, types.List[types.UInt32], types.List[types.PID], *nex.Error) {
+	header, nexError := manager.GetMessageHeader(message)
+	if nexError != nil {
+		return message, nil, nil, nexError
+	}
+
+	var targetConnections []*nex.PRUDPConnection
+	var lstSandboxNodeID types.List[types.UInt32]
+	var lstParticipants types.List[types.PID]
+
+	switch recipientType {
+	case 1: // * PID
+		// TODO - Should we check that the PID exists with manager.Endpoint.AccountDetailsByPID?
+
+		// * We don't have to get the connection if this isn't an instant message or we won't send it
+		if header.UIFlags & 1 != 0 && sendMessage {
+			targetConnection := manager.Endpoint.FindConnectionByPID(uint64(recipientID))
+			if targetConnection != nil {
+				targetConnections = append(targetConnections, targetConnection)
+				lstSandboxNodeID = append(lstSandboxNodeID, types.UInt32(targetConnection.ID))
+				lstParticipants = append(lstParticipants, targetConnection.PID()) // * In official servers this has garbage values, but we will populate it properly
+			}
+		}
+		break
+	case 2: // * Gathering ID
+		if manager.MatchmakingManager == nil {
+			common_globals.Logger.Warning("MessagingManager.MatchmakingManager is not set!")
+			return message, nil, nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "Messages to gatherings are not implemented")
+		}
+
+		// * Check that the gathering exists
+		manager.MatchmakingManager.Mutex.RLock()
+		_, _, participants, _, nexError := match_making_database.FindGatheringByID(manager.MatchmakingManager, uint32(recipientID))
+		if nexError != nil {
+			manager.MatchmakingManager.Mutex.RUnlock()
+			return message, nil, nil, nexError
+		}
+
+		// * We don't have to get the participants connections if this isn't an instant message or we won't send it
+		if header.UIFlags & 1 != 0 && sendMessage {
+			for _, participant := range participants {
+				targetConnection := manager.Endpoint.FindConnectionByPID(participant)
+				if targetConnection == nil {
+					// * This shouldn't happen, but leaving it here just in case
+					common_globals.Logger.Error("Participant in gathering not found in server")
+					continue
+				}
+
+				targetConnections = append(targetConnections, targetConnection)
+				lstSandboxNodeID = append(lstSandboxNodeID, types.UInt32(targetConnection.ID))
+				lstParticipants = append(lstParticipants, targetConnection.PID())
+			}
+		}
+		manager.MatchmakingManager.Mutex.RUnlock()
+		break
+	default:
+		return message, nil, nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Invalid recipient type")
+	}
+
+	if header.UIFlags & 1 != 0 { // * Instant message
+		messageObjectID := message.Object.ObjectID()
+		if messageObjectID.Equals(types.NewString("TextMessage")) {
+			textMessage := message.Object.(messaging_types.TextMessage)
+			nexError = InsertInstantTextMessage(manager, textMessage, recipientID, recipientType)
+			if nexError != nil {
+				return message, nil, nil, nexError
+			}
+		} else if messageObjectID.Equals(types.NewString("BinaryMessage")) {
+			binaryMessage := message.Object.(messaging_types.BinaryMessage)
+			nexError = InsertInstantBinaryMessage(manager, binaryMessage, recipientID, recipientType)
+			if nexError != nil {
+				return message, nil, nil, nexError
+			}
+		} else {
+			return message, nil, nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Invalid data holder object ID")
+		}
+
+		// * MessageDelivery will send the message if the user is connected, while Messaging will not
+		if sendMessage {
+			common_globals.SendMessage(manager.Endpoint, message, targetConnections)
+		}
+	} else {
+		return message, nil, nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "Non-instant messages are not implemented")
+	}
+
+	return message, lstSandboxNodeID, lstParticipants, nil
+}

--- a/messaging/database/process_message.go
+++ b/messaging/database/process_message.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ProcessMessage delivers the given message and stores it in the server
-func ProcessMessage(manager *common_globals.MessagingManager, message types.DataHolder, recipientID types.UInt64, recipientType types.UInt32, sendMessage bool) (types.DataHolder, types.List[types.UInt32], types.List[types.PID], *nex.Error) {
+func ProcessMessage(manager *common_globals.MessagingManager, message types.DataHolder, recipientIDs types.List[types.UInt64], recipientType types.UInt32, sendMessage bool) (types.DataHolder, types.List[types.UInt32], types.List[types.PID], *nex.Error) {
 	header, nexError := manager.GetMessageHeader(message)
 	if nexError != nil {
 		return message, nil, nil, nexError
@@ -25,23 +25,30 @@ func ProcessMessage(manager *common_globals.MessagingManager, message types.Data
 
 		// * We don't have to get the connection if this isn't an instant message or we won't send it
 		if header.UIFlags & 1 != 0 && sendMessage {
-			targetConnection := manager.Endpoint.FindConnectionByPID(uint64(recipientID))
-			if targetConnection != nil {
-				targetConnections = append(targetConnections, targetConnection)
-				lstSandboxNodeID = append(lstSandboxNodeID, types.UInt32(targetConnection.ID))
-				lstParticipants = append(lstParticipants, targetConnection.PID()) // * In official servers this has garbage values, but we will populate it properly
+			for _, recipientID := range recipientIDs {
+				targetConnection := manager.Endpoint.FindConnectionByPID(uint64(recipientID))
+				if targetConnection != nil {
+					targetConnections = append(targetConnections, targetConnection)
+					lstSandboxNodeID = append(lstSandboxNodeID, types.UInt32(targetConnection.ID))
+					lstParticipants = append(lstParticipants, targetConnection.PID()) // * In official servers this has garbage values, but we will populate it properly
+				}
 			}
 		}
-		break
 	case 2: // * Gathering ID
 		if manager.MatchmakingManager == nil {
 			common_globals.Logger.Warning("MessagingManager.MatchmakingManager is not set!")
 			return message, nil, nil, nex.NewError(nex.ResultCodes.Core.NotImplemented, "Messages to gatherings are not implemented")
 		}
 
+		if len(recipientIDs) != 1 {
+			return message, nil, nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Messages to multiple gatherings are not supported")
+		}
+
+		var recipientID uint32 = uint32(recipientIDs[0])
+
 		// * Check that the gathering exists
 		manager.MatchmakingManager.Mutex.RLock()
-		_, _, participants, _, nexError := match_making_database.FindGatheringByID(manager.MatchmakingManager, uint32(recipientID))
+		_, _, participants, _, nexError := match_making_database.FindGatheringByID(manager.MatchmakingManager, recipientID)
 		if nexError != nil {
 			manager.MatchmakingManager.Mutex.RUnlock()
 			return message, nil, nil, nexError
@@ -63,7 +70,6 @@ func ProcessMessage(manager *common_globals.MessagingManager, message types.Data
 			}
 		}
 		manager.MatchmakingManager.Mutex.RUnlock()
-		break
 	default:
 		return message, nil, nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Invalid recipient type")
 	}
@@ -72,15 +78,19 @@ func ProcessMessage(manager *common_globals.MessagingManager, message types.Data
 		messageObjectID := message.Object.ObjectID()
 		if messageObjectID.Equals(types.NewString("TextMessage")) {
 			textMessage := message.Object.(messaging_types.TextMessage)
-			nexError = InsertInstantTextMessage(manager, textMessage, recipientID, recipientType)
-			if nexError != nil {
-				return message, nil, nil, nexError
+			for _, recipientID := range recipientIDs {
+				nexError = InsertInstantTextMessage(manager, textMessage, recipientID, recipientType)
+				if nexError != nil {
+					return message, nil, nil, nexError
+				}
 			}
 		} else if messageObjectID.Equals(types.NewString("BinaryMessage")) {
 			binaryMessage := message.Object.(messaging_types.BinaryMessage)
-			nexError = InsertInstantBinaryMessage(manager, binaryMessage, recipientID, recipientType)
-			if nexError != nil {
-				return message, nil, nil, nexError
+			for _, recipientID := range recipientIDs {
+				nexError = InsertInstantBinaryMessage(manager, binaryMessage, recipientID, recipientType)
+				if nexError != nil {
+					return message, nil, nil, nexError
+				}
 			}
 		} else {
 			return message, nil, nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Invalid data holder object ID")

--- a/messaging/database/process_message.go
+++ b/messaging/database/process_message.go
@@ -99,7 +99,7 @@ func ProcessMessage(manager *common_globals.MessagingManager, message types.Data
 
 		// * MessageDelivery will send the message if the user is connected, while Messaging will not
 		if sendMessage {
-			libraryVersion := manager.Endpoint.LibraryVersions().Messaging
+			libraryVersion := manager.Endpoint.Server.LibraryVersions.Messaging
 
 			// * If sending to PIDs, prepare the message for each of them if multiple targets are set
 			if recipientType == 1 {

--- a/messaging/database/retrieve_all_messages_within_range.go
+++ b/messaging/database/retrieve_all_messages_within_range.go
@@ -1,0 +1,82 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// RetrieveAllMessagesWithinRange retrieves all messages available for the given recipient
+func RetrieveAllMessagesWithinRange(manager *common_globals.MessagingManager, recipientID types.UInt64, recipientType types.UInt32, resultRange types.ResultRange) (types.List[types.DataHolder], *nex.Error) {
+	lstMessages := make(types.List[types.DataHolder], 0, resultRange.Length)
+
+	rows, err := manager.Database.Query(`WITH updated AS (
+		SELECT id FROM messaging.messages WHERE
+			recipient_id = $1 AND
+			recipient_type = $2 AND
+			reception_time + lifetime * INTERVAL '1 second' > NOW() AND
+			read IS NOT TRUE AND
+			deleted IS NOT TRUE
+			OFFSET $3
+			LIMIT $4
+	)
+	UPDATE messaging.messages
+	SET read = true
+	WHERE id IN ( SELECT id FROM updated ) RETURNING
+		id,
+		recipient_id,
+		recipient_type,
+		parent_id,
+		sender_pid,
+		reception_time,
+		lifetime,
+		flags,
+		subject,
+		sender,
+		type
+	`, recipientID, recipientType, resultRange.Offset, resultRange.Length)
+	if err != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	defer rows.Close()
+
+	libraryVersion := manager.Endpoint.Server.LibraryVersions.Messaging
+
+	for rows.Next() {
+		var messageHeader messaging_types.UserMessage
+		var recipientID types.UInt64
+		var recipientType types.UInt32
+		var messageType string
+
+		err = rows.Scan(
+			&messageHeader.UIID,
+			&recipientID,
+			&recipientType,
+			&messageHeader.UIParentID,
+			&messageHeader.PIDSender,
+			&messageHeader.Receptiontime,
+			&messageHeader.UILifeTime,
+			&messageHeader.UIFlags,
+			&messageHeader.StrSubject,
+			&messageHeader.StrSender,
+			&messageType,
+		)
+		if err != nil {
+			return nil, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+		}
+
+		messageHeader = common_globals.SetUserMessageRecipientData(libraryVersion, messageHeader, recipientID, recipientType)
+
+		message, nexError := manager.RetrieveDetailedMessage(manager, messageHeader, messageType)
+		if nexError != nil {
+			return nil, nexError
+		}
+
+		lstMessages = append(lstMessages, message)
+	}
+
+	return lstMessages, nil
+}

--- a/messaging/database/retrieve_detailed_message.go
+++ b/messaging/database/retrieve_detailed_message.go
@@ -1,0 +1,32 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// RetrieveDetailedMessage gets a full message given a message header
+func RetrieveDetailedMessage(manager *common_globals.MessagingManager, messageHeader messaging_types.UserMessage, messageType string) (types.DataHolder, *nex.Error) {
+	var messageHolder types.DataHolder
+	var message types.RVType
+	var nexError *nex.Error
+
+	switch messageType {
+	case "TextMessage":
+		message, nexError = GetTextMessageFromUserMessage(manager, messageHeader)
+	case "BinaryMessage":
+		message, nexError = GetBinaryMessageFromUserMessage(manager, messageHeader)
+	default:
+		return messageHolder, nex.NewError(nex.ResultCodes.Core.Exception, "Invalid message type")
+	}
+
+	if nexError != nil {
+		return messageHolder, nexError
+	}
+
+	messageHolder.Object = message.Copy().(types.DataInterface)
+	return messageHolder, nil
+}

--- a/messaging/database/retrieve_messages.go
+++ b/messaging/database/retrieve_messages.go
@@ -1,0 +1,78 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// RetrieveMessages retrieves the specified messages for the given recipient
+func RetrieveMessages(manager *common_globals.MessagingManager, recipientID types.UInt64, recipientType types.UInt32, lstMsgIDs types.List[types.UInt32], bLeaveOnServer types.Bool) (types.List[types.DataHolder], *nex.Error) {
+	lstMessages := make(types.List[types.DataHolder], 0, len(lstMsgIDs))
+
+	rows, err := manager.Database.Query(`UPDATE messaging.messages SET read = $4 -- Use the inverse of bLeaveOnServer to not mark messages as read if set
+	WHERE
+		recipient_id = $1 AND
+		recipient_type = $2 AND
+		reception_time + lifetime * INTERVAL '1 second' > NOW() AND
+		read IS NOT TRUE AND
+		deleted IS NOT TRUE AND
+		id = ANY($3)
+	RETURNING
+		id,
+		recipient_id,
+		recipient_type,
+		parent_id,
+		sender_pid,
+		reception_time,
+		lifetime,
+		flags,
+		subject,
+		sender,
+		type
+	`, recipientID, recipientType, lstMsgIDs, !bLeaveOnServer)
+	if err != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	defer rows.Close()
+
+	libraryVersion := manager.Endpoint.Server.LibraryVersions.Messaging
+
+	for rows.Next() {
+		var messageHeader messaging_types.UserMessage
+		var recipientID types.UInt64
+		var recipientType types.UInt32
+		var messageType string
+
+		err = rows.Scan(
+			&messageHeader.UIID,
+			&recipientID,
+			&recipientType,
+			&messageHeader.UIParentID,
+			&messageHeader.PIDSender,
+			&messageHeader.Receptiontime,
+			&messageHeader.UILifeTime,
+			&messageHeader.UIFlags,
+			&messageHeader.StrSubject,
+			&messageHeader.StrSender,
+			&messageType,
+		)
+		if err != nil {
+			return nil, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+		}
+
+		messageHeader = common_globals.SetUserMessageRecipientData(libraryVersion, messageHeader, recipientID, recipientType)
+
+		message, nexError := manager.RetrieveDetailedMessage(manager, messageHeader, messageType)
+		if nexError != nil {
+			return nil, nexError
+		}
+
+		lstMessages = append(lstMessages, message)
+	}
+
+	return lstMessages, nil
+}

--- a/messaging/database/validate_message_recipient.go
+++ b/messaging/database/validate_message_recipient.go
@@ -1,0 +1,45 @@
+package database
+
+import (
+	"slices"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	match_making_database "github.com/PretendoNetwork/nex-protocols-common-go/v2/match-making/database"
+)
+
+// ValidateMessageRecipient checks that the given PID can access the given recipient data
+func ValidateMessageRecipient(manager *common_globals.MessagingManager, pid types.PID, recipientID types.UInt64, recipientType types.UInt32) bool {
+	switch recipientType {
+	case 1: // * PID - Valid if the recipient ID is the same as the given PID
+		if pid != types.PID(recipientID) {
+			return false
+		}
+
+		return true
+	case 2: // * Gathering ID - Valid if the given PID is a participant on the gathering
+		if manager.MatchmakingManager == nil {
+			common_globals.Logger.Warning("MessagingManager.MatchmakingManager is not set!")
+			return false
+		}
+
+		// * Check that the gathering exists
+		manager.MatchmakingManager.Mutex.RLock()
+		defer manager.MatchmakingManager.Mutex.RUnlock()
+		_, _, participants, _, nexError := match_making_database.FindGatheringByID(manager.MatchmakingManager, uint32(recipientID))
+		if nexError != nil {
+			common_globals.Logger.Error(nexError.Error())
+			return false
+		}
+
+		if !slices.Contains(participants, uint64(pid)) {
+			return false
+		}
+
+		return true
+	}
+
+	common_globals.Logger.Errorf("Invalid recipient type %d", recipientType)
+	return false
+}

--- a/messaging/delete_all_messages.go
+++ b/messaging/delete_all_messages.go
@@ -1,0 +1,51 @@
+package messaging
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+
+	messaging "github.com/PretendoNetwork/nex-protocols-go/v2/messaging"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	messaging_database "github.com/PretendoNetwork/nex-protocols-common-go/v2/messaging/database"
+)
+
+func (commonProtocol *CommonProtocol) deleteAllMessages(err error, packet nex.PacketInterface, callID uint32, recipient messaging_types.MessageRecipient) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, err.Error())
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+	server := endpoint.Server
+
+	libraryVersion := server.LibraryVersions.Messaging
+
+	var uiNbDeletedMessages types.UInt32 = 0
+	var nexError *nex.Error
+
+	recipientID, recipientType := common_globals.GetMessageRecipientData(libraryVersion, recipient)
+
+	// * If the MessageRecipient is invalid, just return 0
+	if valid := commonProtocol.manager.ValidateMessageRecipient(commonProtocol.manager, connection.PID(), recipientID, recipientType); valid {
+		uiNbDeletedMessages, nexError = messaging_database.DeleteAllMessages(commonProtocol.manager, recipientID, recipientType)
+		if nexError != nil {
+			return nil, nexError
+		}
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	uiNbDeletedMessages.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = messaging.ProtocolID
+	rmcResponse.MethodID = messaging.MethodDeleteAllMessages
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/messaging/delete_messages.go
+++ b/messaging/delete_messages.go
@@ -1,0 +1,48 @@
+package messaging
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+
+	messaging "github.com/PretendoNetwork/nex-protocols-go/v2/messaging"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	messaging_database "github.com/PretendoNetwork/nex-protocols-common-go/v2/messaging/database"
+)
+
+func (commonProtocol *CommonProtocol) deleteMessages(err error, packet nex.PacketInterface, callID uint32, recipient messaging_types.MessageRecipient, lstMessagesToDelete types.List[types.UInt32]) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, err.Error())
+	}
+
+	if len(lstMessagesToDelete) == 0 {
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "lstMessagesToDelete must not be empty")
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+	server := endpoint.Server
+
+	libraryVersion := server.LibraryVersions.Messaging
+
+	var nexError *nex.Error
+
+	recipientID, recipientType := common_globals.GetMessageRecipientData(libraryVersion, recipient)
+
+	// * If the MessageRecipient is invalid, just do nothing
+	if valid := commonProtocol.manager.ValidateMessageRecipient(commonProtocol.manager, connection.PID(), recipientID, recipientType); valid {
+		nexError = messaging_database.DeleteMessages(commonProtocol.manager, recipientID, recipientType, lstMessagesToDelete)
+		if nexError != nil {
+			return nil, nexError
+		}
+	}
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, nil)
+	rmcResponse.ProtocolID = messaging.ProtocolID
+	rmcResponse.MethodID = messaging.MethodDeleteMessages
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/messaging/deliver_message.go
+++ b/messaging/deliver_message.go
@@ -1,4 +1,4 @@
-package message_delivery
+package messaging
 
 import (
 	"github.com/PretendoNetwork/nex-go/v2"

--- a/messaging/deliver_message.go
+++ b/messaging/deliver_message.go
@@ -1,0 +1,52 @@
+package message_delivery
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+
+	messaging "github.com/PretendoNetwork/nex-protocols-go/v2/messaging"
+)
+
+func (commonProtocol *CommonProtocol) deliverMessage(err error, packet nex.PacketInterface, callID uint32, oUserMessage types.DataHolder) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, err.Error())
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+
+	recipientID, recipientType, nexError := commonProtocol.manager.ValidateMessage(oUserMessage)
+	if nexError != nil {
+		common_globals.Logger.Error(nexError.Error())
+		return nil, nexError
+	}
+
+	oUserMessage, nexError = commonProtocol.manager.PrepareMessage(connection.PID(), oUserMessage)
+	if nexError != nil {
+		common_globals.Logger.Error(nexError.Error())
+		return nil, nexError
+	}
+
+	oModifiedMessage, lstSandboxNodeID, lstParticipants, nexError := commonProtocol.manager.ProcessMessage(commonProtocol.manager, oUserMessage, types.List[types.UInt64]{recipientID}, recipientType, false)
+	if nexError != nil {
+		common_globals.Logger.Error(nexError.Error())
+		return nil, nexError
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	oModifiedMessage.WriteTo(rmcResponseStream)
+	lstSandboxNodeID.WriteTo(rmcResponseStream)
+	lstParticipants.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = messaging.ProtocolID
+	rmcResponse.MethodID = messaging.MethodDeliverMessage
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/messaging/deliver_message_multi_target.go
+++ b/messaging/deliver_message_multi_target.go
@@ -17,6 +17,12 @@ func (commonProtocol *CommonProtocol) deliverMessageMultiTarget(err error, packe
 	connection := packet.Sender().(*nex.PRUDPConnection)
 	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
 
+	// * Only allow up to 100 targets, based on the maximum amount of friends allowed
+	if len(lstTarget) > 100 {
+		common_globals.Logger.Error("Message has over 100 targets")
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Message has over 100 targets")
+	}
+
 	_, _, nexError := commonProtocol.manager.ValidateMessage(oUserMessage)
 	if nexError != nil {
 		common_globals.Logger.Error(nexError.Error())

--- a/messaging/deliver_message_multi_target.go
+++ b/messaging/deliver_message_multi_target.go
@@ -1,0 +1,57 @@
+package message_delivery
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+
+	messaging "github.com/PretendoNetwork/nex-protocols-go/v2/messaging"
+)
+
+func (commonProtocol *CommonProtocol) deliverMessageMultiTarget(err error, packet nex.PacketInterface, callID uint32, lstTarget types.List[types.PID], oUserMessage types.DataHolder) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, err.Error())
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+
+	_, _, nexError := commonProtocol.manager.ValidateMessage(oUserMessage)
+	if nexError != nil {
+		common_globals.Logger.Error(nexError.Error())
+		return nil, nexError
+	}
+
+	oUserMessage, nexError = commonProtocol.manager.PrepareMessage(connection.PID(), oUserMessage)
+	if nexError != nil {
+		common_globals.Logger.Error(nexError.Error())
+		return nil, nexError
+	}
+
+	recipientIDs := make(types.List[types.UInt64], len(lstTarget))
+	for i, recipientID := range lstTarget {
+		recipientIDs[i] = types.UInt64(recipientID)
+	}
+
+	oModifiedMessage, lstSandboxNodeID, lstParticipants, nexError := commonProtocol.manager.ProcessMessage(commonProtocol.manager, oUserMessage, recipientIDs, 1, false)
+	if nexError != nil {
+		common_globals.Logger.Error(nexError.Error())
+		return nil, nexError
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	oModifiedMessage.WriteTo(rmcResponseStream)
+	lstSandboxNodeID.WriteTo(rmcResponseStream)
+	lstParticipants.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = messaging.ProtocolID
+	rmcResponse.MethodID = messaging.MethodDeliverMessage
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/messaging/deliver_message_multi_target.go
+++ b/messaging/deliver_message_multi_target.go
@@ -1,4 +1,4 @@
-package message_delivery
+package messaging
 
 import (
 	"github.com/PretendoNetwork/nex-go/v2"

--- a/messaging/get_messages_headers.go
+++ b/messaging/get_messages_headers.go
@@ -1,0 +1,57 @@
+package messaging
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+
+	messaging "github.com/PretendoNetwork/nex-protocols-go/v2/messaging"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	messaging_database "github.com/PretendoNetwork/nex-protocols-common-go/v2/messaging/database"
+)
+
+func (commonProtocol *CommonProtocol) getMessagesHeaders(err error, packet nex.PacketInterface, callID uint32, recipient messaging_types.MessageRecipient, resultRange types.ResultRange) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, err.Error())
+	}
+
+	// * There doesn't seem to be a limit on official servers, as you can query messages with a length over 100
+	// * We will impose that limit ourselves to prevent abuse
+	if resultRange.Length > 100 {
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "ResultRange.Length is over 100")
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+	server := endpoint.Server
+
+	libraryVersion := server.LibraryVersions.Messaging
+
+	var lstMsgHeaders types.List[messaging_types.UserMessage]
+	var nexError *nex.Error
+
+	recipientID, recipientType := common_globals.GetMessageRecipientData(libraryVersion, recipient)
+
+	// * If the MessageRecipient is invalid, just return no entries
+	if valid := commonProtocol.manager.ValidateMessageRecipient(commonProtocol.manager, connection.PID(), recipientID, recipientType); valid {
+		lstMsgHeaders, nexError = messaging_database.GetMessagesHeaders(commonProtocol.manager, recipientID, recipientType, resultRange)
+		if nexError != nil {
+			return nil, nexError
+		}
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	lstMsgHeaders.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = messaging.ProtocolID
+	rmcResponse.MethodID = messaging.MethodGetMessagesHeaders
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/messaging/get_number_of_messages.go
+++ b/messaging/get_number_of_messages.go
@@ -1,0 +1,51 @@
+package messaging
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+
+	messaging "github.com/PretendoNetwork/nex-protocols-go/v2/messaging"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	messaging_database "github.com/PretendoNetwork/nex-protocols-common-go/v2/messaging/database"
+)
+
+func (commonProtocol *CommonProtocol) getNumberOfMessages(err error, packet nex.PacketInterface, callID uint32, recipient messaging_types.MessageRecipient) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, err.Error())
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+	server := endpoint.Server
+
+	libraryVersion := server.LibraryVersions.Messaging
+
+	var uiNbMessages types.UInt32 = 0
+	var nexError *nex.Error
+
+	recipientID, recipientType := common_globals.GetMessageRecipientData(libraryVersion, recipient)
+
+	// * If the MessageRecipient is invalid, just return 0
+	if valid := commonProtocol.manager.ValidateMessageRecipient(commonProtocol.manager, connection.PID(), recipientID, recipientType); valid {
+		uiNbMessages, nexError = messaging_database.GetNumberOfMessages(commonProtocol.manager, recipientID, recipientType)
+		if nexError != nil {
+			return nil, nexError
+		}
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	uiNbMessages.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = messaging.ProtocolID
+	rmcResponse.MethodID = messaging.MethodGetNumberOfMessages
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/messaging/protocol.go
+++ b/messaging/protocol.go
@@ -1,4 +1,4 @@
-package message_delivery
+package messaging
 
 import (
 	"github.com/PretendoNetwork/nex-go/v2"
@@ -32,11 +32,11 @@ func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.Messagi
 	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.instant_messages (
 		id bigserial PRIMARY KEY,
 		recipient_id numeric(20),
-		recipient_type numeric(10),
+		recipient_type bigint,
 		parent_id bigint,
 		sender_pid numeric(20),
 		reception_time timestamp,
-		lifetime numeric(10),
+		lifetime bigint,
 		flags bigint,
 		subject text,
 		sender text,
@@ -68,11 +68,11 @@ func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.Messagi
 	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.messages (
 		id bigserial PRIMARY KEY,
 		recipient_id numeric(20),
-		recipient_type numeric(10),
+		recipient_type bigint,
 		parent_id bigint,
 		sender_pid numeric(20),
 		reception_time timestamp,
-		lifetime numeric(10),
+		lifetime bigint,
 		flags bigint,
 		subject text,
 		sender text,
@@ -112,6 +112,7 @@ func NewCommonProtocol(protocol messaging.Interface) *CommonProtocol {
 	}
 
 	protocol.SetHandlerDeliverMessage(commonProtocol.deliverMessage)
+	protocol.SetHandlerGetNumberOfMessages(commonProtocol.getNumberOfMessages)
 	protocol.SetHandlerDeliverMessageMultiTarget(commonProtocol.deliverMessageMultiTarget)
 
 	return commonProtocol

--- a/messaging/protocol.go
+++ b/messaging/protocol.go
@@ -23,6 +23,14 @@ func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.Messagi
 		manager.ProcessMessage = messaging_database.ProcessMessage
 	}
 
+	if manager.ValidateMessageRecipient == nil {
+		manager.ValidateMessageRecipient = messaging_database.ValidateMessageRecipient
+	}
+
+	if manager.RetrieveDetailedMessage == nil {
+		manager.RetrieveDetailedMessage = messaging_database.RetrieveDetailedMessage
+	}
+
 	_, err = manager.Database.Exec(`CREATE SCHEMA IF NOT EXISTS messaging`)
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
@@ -114,6 +122,8 @@ func NewCommonProtocol(protocol messaging.Interface) *CommonProtocol {
 	protocol.SetHandlerDeliverMessage(commonProtocol.deliverMessage)
 	protocol.SetHandlerGetNumberOfMessages(commonProtocol.getNumberOfMessages)
 	protocol.SetHandlerGetMessagesHeaders(commonProtocol.getMessagesHeaders)
+	protocol.SetHandlerRetrieveAllMessagesWithinRange(commonProtocol.retrieveAllMessagesWithinRange)
+	protocol.SetHandlerRetrieveMessages(commonProtocol.retrieveMessages)
 	protocol.SetHandlerDeleteMessages(commonProtocol.deleteMessages)
 	protocol.SetHandlerDeleteAllMessages(commonProtocol.deleteAllMessages)
 	protocol.SetHandlerDeliverMessageMultiTarget(commonProtocol.deliverMessageMultiTarget)

--- a/messaging/protocol.go
+++ b/messaging/protocol.go
@@ -115,6 +115,7 @@ func NewCommonProtocol(protocol messaging.Interface) *CommonProtocol {
 	protocol.SetHandlerGetNumberOfMessages(commonProtocol.getNumberOfMessages)
 	protocol.SetHandlerGetMessagesHeaders(commonProtocol.getMessagesHeaders)
 	protocol.SetHandlerDeleteMessages(commonProtocol.deleteMessages)
+	protocol.SetHandlerDeleteAllMessages(commonProtocol.deleteAllMessages)
 	protocol.SetHandlerDeliverMessageMultiTarget(commonProtocol.deliverMessageMultiTarget)
 
 	return commonProtocol

--- a/messaging/protocol.go
+++ b/messaging/protocol.go
@@ -1,0 +1,80 @@
+package message_delivery
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	messaging "github.com/PretendoNetwork/nex-protocols-go/v2/messaging"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	messaging_database "github.com/PretendoNetwork/nex-protocols-common-go/v2/messaging/database"
+)
+
+type CommonProtocol struct {
+	endpoint              nex.EndpointInterface
+	protocol              messaging.Interface
+	manager               *common_globals.MessagingManager
+}
+
+// SetManager defines the messaging manager to be used by the common protocol
+func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.MessagingManager) {
+	var err error
+
+	commonProtocol.manager = manager
+
+	if manager.ProcessMessage == nil {
+		manager.ProcessMessage = messaging_database.ProcessMessage
+	}
+
+	_, err = manager.Database.Exec(`CREATE SCHEMA IF NOT EXISTS messaging`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.instant_messages (
+		id bigserial PRIMARY KEY,
+		recipient_id numeric(20),
+		recipient_type numeric(10),
+		parent_id bigint,
+		sender_pid numeric(20),
+		reception_time timestamp,
+		lifetime numeric(10),
+		flags bigint,
+		subject text,
+		sender text,
+		type text NOT NULL DEFAULT ''
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.instant_text_messages (
+		id bigint PRIMARY KEY REFERENCES messaging.instant_messages(id),
+		body text
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.instant_binary_messages (
+		id bigint PRIMARY KEY REFERENCES messaging.instant_messages(id),
+		body bytea
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+}
+
+// NewCommonProtocol returns a new CommonProtocol
+func NewCommonProtocol(protocol messaging.Interface) *CommonProtocol {
+	commonProtocol := &CommonProtocol{
+		endpoint: protocol.Endpoint(),
+		protocol: protocol,
+	}
+
+	protocol.SetHandlerDeliverMessage(commonProtocol.deliverMessage)
+	protocol.SetHandlerDeliverMessageMultiTarget(commonProtocol.deliverMessageMultiTarget)
+
+	return commonProtocol
+}

--- a/messaging/protocol.go
+++ b/messaging/protocol.go
@@ -64,6 +64,44 @@ func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.Messagi
 		common_globals.Logger.Error(err.Error())
 		return
 	}
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.messages (
+		id bigserial PRIMARY KEY,
+		recipient_id numeric(20),
+		recipient_type numeric(10),
+		parent_id bigint,
+		sender_pid numeric(20),
+		reception_time timestamp,
+		lifetime numeric(10),
+		flags bigint,
+		subject text,
+		sender text,
+		type text NOT NULL DEFAULT '',
+		read boolean NOT NULL DEFAULT false,
+		deleted boolean NOT NULL DEFAULT false
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.text_messages (
+		id bigint PRIMARY KEY REFERENCES messaging.messages(id),
+		body text
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS messaging.binary_messages (
+		id bigint PRIMARY KEY REFERENCES messaging.messages(id),
+		body bytea
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
 }
 
 // NewCommonProtocol returns a new CommonProtocol

--- a/messaging/protocol.go
+++ b/messaging/protocol.go
@@ -114,6 +114,7 @@ func NewCommonProtocol(protocol messaging.Interface) *CommonProtocol {
 	protocol.SetHandlerDeliverMessage(commonProtocol.deliverMessage)
 	protocol.SetHandlerGetNumberOfMessages(commonProtocol.getNumberOfMessages)
 	protocol.SetHandlerGetMessagesHeaders(commonProtocol.getMessagesHeaders)
+	protocol.SetHandlerDeleteMessages(commonProtocol.deleteMessages)
 	protocol.SetHandlerDeliverMessageMultiTarget(commonProtocol.deliverMessageMultiTarget)
 
 	return commonProtocol

--- a/messaging/protocol.go
+++ b/messaging/protocol.go
@@ -113,6 +113,7 @@ func NewCommonProtocol(protocol messaging.Interface) *CommonProtocol {
 
 	protocol.SetHandlerDeliverMessage(commonProtocol.deliverMessage)
 	protocol.SetHandlerGetNumberOfMessages(commonProtocol.getNumberOfMessages)
+	protocol.SetHandlerGetMessagesHeaders(commonProtocol.getMessagesHeaders)
 	protocol.SetHandlerDeliverMessageMultiTarget(commonProtocol.deliverMessageMultiTarget)
 
 	return commonProtocol

--- a/messaging/retrieve_all_messages_within_range.go
+++ b/messaging/retrieve_all_messages_within_range.go
@@ -1,0 +1,57 @@
+package messaging
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+
+	messaging "github.com/PretendoNetwork/nex-protocols-go/v2/messaging"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	messaging_database "github.com/PretendoNetwork/nex-protocols-common-go/v2/messaging/database"
+)
+
+func (commonProtocol *CommonProtocol) retrieveAllMessagesWithinRange(err error, packet nex.PacketInterface, callID uint32, recipient messaging_types.MessageRecipient, resultRange types.ResultRange) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, err.Error())
+	}
+
+	// * There doesn't seem to be a limit on official servers, as you can query messages with a length over 100
+	// * We will impose that limit ourselves to prevent abuse
+	if resultRange.Length > 100 {
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "ResultRange.Length is over 100")
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+	server := endpoint.Server
+
+	libraryVersion := server.LibraryVersions.Messaging
+
+	var lstMessages types.List[types.DataHolder]
+	var nexError *nex.Error
+
+	recipientID, recipientType := common_globals.GetMessageRecipientData(libraryVersion, recipient)
+
+	// * If the MessageRecipient is invalid, just return no entries
+	if valid := commonProtocol.manager.ValidateMessageRecipient(commonProtocol.manager, connection.PID(), recipientID, recipientType); valid {
+		lstMessages, nexError = messaging_database.RetrieveAllMessagesWithinRange(commonProtocol.manager, recipientID, recipientType, resultRange)
+		if nexError != nil {
+			return nil, nexError
+		}
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	lstMessages.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = messaging.ProtocolID
+	rmcResponse.MethodID = messaging.MethodRetrieveAllMessagesWithinRange
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/messaging/retrieve_messages.go
+++ b/messaging/retrieve_messages.go
@@ -21,6 +21,11 @@ func (commonProtocol *CommonProtocol) retrieveMessages(err error, packet nex.Pac
 		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "lstMsgIDs must not be empty")
 	}
 
+	// * Only allow up to 100 messages
+	if len(lstMsgIDs) > 100 {
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Trying to query over 100 messages")
+	}
+
 	connection := packet.Sender().(*nex.PRUDPConnection)
 	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
 	server := endpoint.Server

--- a/messaging/retrieve_messages.go
+++ b/messaging/retrieve_messages.go
@@ -1,0 +1,55 @@
+package messaging
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+
+	messaging "github.com/PretendoNetwork/nex-protocols-go/v2/messaging"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	messaging_database "github.com/PretendoNetwork/nex-protocols-common-go/v2/messaging/database"
+)
+
+func (commonProtocol *CommonProtocol) retrieveMessages(err error, packet nex.PacketInterface, callID uint32, recipient messaging_types.MessageRecipient, lstMsgIDs types.List[types.UInt32], bLeaveOnServer types.Bool) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, err.Error())
+	}
+
+	if len(lstMsgIDs) == 0 {
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "lstMsgIDs must not be empty")
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+	server := endpoint.Server
+
+	libraryVersion := server.LibraryVersions.Messaging
+
+	var lstMessages types.List[types.DataHolder]
+	var nexError *nex.Error
+
+	recipientID, recipientType := common_globals.GetMessageRecipientData(libraryVersion, recipient)
+
+	// * If the MessageRecipient is invalid, just return no entries
+	if valid := commonProtocol.manager.ValidateMessageRecipient(commonProtocol.manager, connection.PID(), recipientID, recipientType); valid {
+		lstMessages, nexError = messaging_database.RetrieveMessages(commonProtocol.manager, recipientID, recipientType, lstMsgIDs, bLeaveOnServer)
+		if nexError != nil {
+			return nil, nexError
+		}
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	lstMessages.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = messaging.ProtocolID
+	rmcResponse.MethodID = messaging.MethodRetrieveMessages
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

This PR aims to implement complete common protocols of Messaging and MessageDelivery. At the moment, only  MessageDelivery::DeliverMessage has been added as a base, along with instant messages. This is done to allow reviewing the design and structure that the common protocols will have. **These changes haven't been tested, and have only been pushed for allowing review of the current design.**

### Task list

- `Messaging`
  - [x] `Messaging::DeliverMessage`
  - [x] `Messaging::GetNumberOfMessages`
  - [x] `Messaging::GetMessagesHeaders`
  - [x] `Messaging::RetrieveAllMessagesWithinRange`
  - [x] `Messaging::RetrieveMessages`
  - [x] `Messaging::DeleteMessages`
  - [x] `Messaging::DeleteAllMessages`
  - [x] `Messaging::DeliverMessageMultiTarget`

- `MessageDelivery`
  - [x] `MessageDelivery::DeliverMessage`
  - [x] `MessageDelivery::DeliverMessageMultiTarget`

### Design

Following the design of common Matchmaking, these protocols will have a shared `MessagingManager` that the protocols will be able to access in order to interact with the underlying database that will store the messages. This manager has been designed with modularity in mind, allowing customizations like extensions to recipient types or additional structures that inherit from `UserMessage` to integrate on the existing code with little complexity.

In order to achieve this goal, the `MessagingManager` allows changing certain functions used on different contexts. The following is a list of those functions, and may be expanded as more methods and functionality get implemented:
- `ValidateMessage`: Used for validating the fields of a message, allowing integration of custom message types
- `GetMessageHeader`: Used for retrieving the common `UserMessage` header from a specific message type
- `SetMessageHeader`: Used for setting the common `UserMessage` header on a specific message type
- `ProcessMessage`: Called when delivering a new message

For each of those functions a default implementation is given by either the `MessagingManager` itself or the common protocols, in order to accomodate the necessity of accessing functionality of other common protocols like matchmaking. Following that, the `MessagingManager` includes an **optional** parameter for a `MatchmakingManager`, which will be used on games that send messages to a gathering.

The database functionality is implemented under the `messaging` protocol, while `message-delivery` will access it using the same functions as `messaging`, in a similar fashion to how `match-making-ext` interacts with matchmaking functionality using the functions implemented under `match-making`. The database creation functions will probably be duplicated in both protocols in order to handle games which will only use one of the protocols, like exclusively using `MessageDelivery`, for example.

Finally, in order to handle changes made to the `UserMessage` structure on NEX 4.0 and later where the message recipient information was moved from individual fields to a `MessageRecipient` parameter, a getter `GetUserMessageRecipientData` and setter is implemented for accessing this information while handling versioning differences.

Regarding the database, it will have the following structure:
- `messaging` as the main schema. Inside it there will be tables for handling various functionality, like:
  - `messages` for the common base `UserMessage` of *non-instant* messages. Instant messages have a separate table since those technically don't have an ID assigned, but we will store them for tracking purposes
  - `text_messages` for storing the `TextMessage`-specific data, and will be linked to the `messages` table by ID
  - `binary_messages` for storing the `BinaryMessage`-specific data, and will be linked to the `messages` table by ID
  - `instant_messages` for the common base `UserMessage` of *instant* messages
  - `instant_text_messages` for storing the `TextMessage`-specific data, and will be linked to the `instant_messages` table by ID
  - `instant_binary_messages` for storing the `BinaryMessage`-specific data, and will be linked to the `instant_messages` table by ID

### Notes for server implementers

If you want to test these changes, you can use code similar to the following, adjusting it for your necessities:

```go
messagingManager := common_globals.NewMessagingManager(globals.SecureEndpoint, database.Postgres)

messageDeliveryProtocol := message_delivery.NewProtocol()
globals.SecureEndpoint.RegisterServiceProtocol(messageDeliveryProtocol)
commonMessageDeliveryProtocol := common_message_melivery.NewCommonProtocol(messageDeliveryProtocol)
commonMessageDeliveryProtocol.SetManager(messageDeliveryManager)
```

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.