### PR TITLE
feat(datastore): Implement notifications

### DIFF
--- a/datastore/database/get_new_arrived_notifications.go
+++ b/datastore/database/get_new_arrived_notifications.go
@@ -1,0 +1,53 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	datastore_types "github.com/PretendoNetwork/nex-protocols-go/v2/datastore/types"
+)
+
+func GetNewArrivedNotifications(manager *common_globals.DataStoreManager, recipientID types.PID, param datastore_types.DataStoreGetNewArrivedNotificationsParam) (types.List[datastore_types.DataStoreNotification], types.Bool, *nex.Error) {
+	// * First we mark all unread notifications as read
+	_, err := manager.Database.Exec(`UPDATE datastore.notifications SET read = true, read_date = (CURRENT_TIMESTAMP AT TIME ZONE 'UTC') WHERE recipient_id = $1 AND id <= $2 AND read IS NOT TRUE`, recipientID, param.LastNotificationID)
+	if err != nil {
+		// TODO - Send more specific errors?
+		return nil, false, nex.NewError(nex.ResultCodes.DataStore.Unknown, err.Error())
+	}
+
+	var pResult types.List[datastore_types.DataStoreNotification]
+	var pHasNext types.Bool = false
+
+	// * Get the full count so we can determine if we are giving all notifications
+	var notificationsCount uint64
+	err = manager.Database.QueryRow(`SELECT COUNT(id) FROM datastore.notifications WHERE recipient_id = $1 AND read IS NOT TRUE`, recipientID).Scan(&notificationsCount)
+	if err != nil {
+		// TODO - Send more specific errors?
+		return nil, false, nex.NewError(nex.ResultCodes.DataStore.Unknown, err.Error())
+	}
+
+	rows, err := manager.Database.Query(`SELECT id, data_id FROM datastore.notifications WHERE recipient_id = $1 AND read IS NOT TRUE LIMIT $2`, recipientID, param.Limit)
+	if err != nil {
+		// TODO - Send more specific errors?
+		return nil, false, nex.NewError(nex.ResultCodes.DataStore.Unknown, err.Error())
+	}
+
+	for rows.Next() {
+		var notification datastore_types.DataStoreNotification
+		err = rows.Scan(&notification.NotificationID, &notification.DataID)
+		if err != nil {
+			// TODO - Send more specific errors?
+			return nil, false, nex.NewError(nex.ResultCodes.DataStore.Unknown, err.Error())
+		}
+
+		pResult = append(pResult, notification)
+	}
+
+	rows.Close()
+
+	if notificationsCount > uint64(len(pResult)) {
+		pHasNext = true
+	}
+
+	return pResult, pHasNext, nil
+}

--- a/datastore/database/send_notification.go
+++ b/datastore/database/send_notification.go
@@ -26,9 +26,9 @@ func SendNotification(manager *common_globals.DataStoreManager, dataID uint64, r
 		return nex.NewError(nex.ResultCodes.DataStore.Unknown, err.Error())
 	}
 
-	key := fmt.Sprintf("%s/%020d.bin", manager.S3.NotifyKeyBase, recipientID)
+	key := fmt.Sprintf("%s/notifications/%020d.bin", manager.S3.KeyBase, recipientID)
 	data := fmt.Sprintf("%d,%d,%d", notificationID, recipientID, manager.NotifyTimestamp)
-	err = manager.S3.Presigner.PutObject(manager.S3.Bucket, key, data)
+	err = manager.S3.Manager.PutObject(manager.S3.Bucket, key, data)
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nex.NewError(nex.ResultCodes.DataStore.Unknown, "Failed to put notifier")

--- a/datastore/database/send_notification.go
+++ b/datastore/database/send_notification.go
@@ -1,0 +1,38 @@
+package database
+
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+func SendNotification(manager *common_globals.DataStoreManager, dataID uint64, recipientID, senderPID types.PID) *nex.Error {
+	var notificationID uint64
+
+	err := manager.Database.QueryRow(`INSERT INTO datastore.notifications (
+		data_id,
+		recipient_id,
+		sender_pid
+	) VALUES (
+		$1,
+		$2,
+		$3
+	) RETURNING id`, dataID, recipientID, senderPID).Scan(&notificationID)
+
+	if err != nil {
+		// TODO - Send more specific errors?
+		return nex.NewError(nex.ResultCodes.DataStore.Unknown, err.Error())
+	}
+
+	key := fmt.Sprintf("%s/%020d.bin", manager.S3.NotifyKeyBase, recipientID)
+	data := fmt.Sprintf("%d,%d,%d", notificationID, recipientID, manager.NotifyTimestamp)
+	err = manager.S3.Presigner.PutObject(manager.S3.Bucket, key, data)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nex.NewError(nex.ResultCodes.DataStore.Unknown, "Failed to put notifier")
+	}
+
+	return nil
+}

--- a/datastore/get_new_arrived_notifications.go
+++ b/datastore/get_new_arrived_notifications.go
@@ -1,0 +1,44 @@
+package datastore
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	"github.com/PretendoNetwork/nex-protocols-common-go/v2/datastore/database"
+	datastore "github.com/PretendoNetwork/nex-protocols-go/v2/datastore"
+	datastore_constants "github.com/PretendoNetwork/nex-protocols-go/v2/datastore/constants"
+	datastore_types "github.com/PretendoNetwork/nex-protocols-go/v2/datastore/types"
+)
+
+func (commonProtocol *CommonProtocol) getNewArrivedNotfications(err error, packet nex.PacketInterface, callID uint32, param datastore_types.DataStoreGetNewArrivedNotificationsParam) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.DataStore.Unknown, err.Error())
+	}
+
+	if uint32(param.Limit) > datastore_constants.MaxSearchResultSize {
+		return nil, nex.NewError(nex.ResultCodes.DataStore.InvalidArgument, "change_error")
+	}
+
+	manager := commonProtocol.manager
+	connection := packet.Sender()
+	endpoint := connection.Endpoint()
+
+	pResult, pHasNext, errCode := database.GetNewArrivedNotifications(manager, connection.PID(), param)
+	if errCode != nil {
+		return nil, errCode
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	pResult.WriteTo(rmcResponseStream)
+	pHasNext.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = datastore.ProtocolID
+	rmcResponse.MethodID = datastore.MethodGetNewArrivedNotifications
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/datastore/get_new_arrived_notifications_v1.go
+++ b/datastore/get_new_arrived_notifications_v1.go
@@ -30,6 +30,7 @@ func (commonProtocol *CommonProtocol) getNewArrivedNotficationsV1(err error, pac
 	}
 
 	// * Convert types.List[datastore_types.DataStoreNotification] to types.List[datastore_types.DataStoreNotificationV1]
+	// TODO - Handle case where the data ID is bigger than the maximum supported on a uint32
 	pResult := make(types.List[datastore_types.DataStoreNotificationV1], len(pResultRaw))
 	for i, notification := range pResultRaw {
 		pResult[i].NotificationID = notification.NotificationID
@@ -45,7 +46,7 @@ func (commonProtocol *CommonProtocol) getNewArrivedNotficationsV1(err error, pac
 
 	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
 	rmcResponse.ProtocolID = datastore.ProtocolID
-	rmcResponse.MethodID = datastore.MethodGetNewArrivedNotifications
+	rmcResponse.MethodID = datastore.MethodGetNewArrivedNotificationsV1
 	rmcResponse.CallID = callID
 
 	return rmcResponse, nil

--- a/datastore/get_new_arrived_notifications_v1.go
+++ b/datastore/get_new_arrived_notifications_v1.go
@@ -1,0 +1,53 @@
+package datastore
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-common-go/v2/datastore/database"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	datastore "github.com/PretendoNetwork/nex-protocols-go/v2/datastore"
+	datastore_constants "github.com/PretendoNetwork/nex-protocols-go/v2/datastore/constants"
+	datastore_types "github.com/PretendoNetwork/nex-protocols-go/v2/datastore/types"
+)
+
+func (commonProtocol *CommonProtocol) getNewArrivedNotficationsV1(err error, packet nex.PacketInterface, callID uint32, param datastore_types.DataStoreGetNewArrivedNotificationsParam) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.DataStore.Unknown, err.Error())
+	}
+
+	if uint32(param.Limit) > datastore_constants.MaxSearchResultSize {
+		return nil, nex.NewError(nex.ResultCodes.DataStore.InvalidArgument, "change_error")
+	}
+
+	manager := commonProtocol.manager
+	connection := packet.Sender()
+	endpoint := connection.Endpoint()
+
+	pResultRaw, pHasNext, errCode := database.GetNewArrivedNotifications(manager, connection.PID(), param)
+	if errCode != nil {
+		return nil, errCode
+	}
+
+	// * Convert types.List[datastore_types.DataStoreNotification] to types.List[datastore_types.DataStoreNotificationV1]
+	pResult := make(types.List[datastore_types.DataStoreNotificationV1], len(pResultRaw))
+	for i, notification := range pResultRaw {
+		pResult[i].NotificationID = notification.NotificationID
+		pResult[i].DataID = types.UInt32(notification.DataID)
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	pResult.WriteTo(rmcResponseStream)
+	pHasNext.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = datastore.ProtocolID
+	rmcResponse.MethodID = datastore.MethodGetNewArrivedNotifications
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}
+

--- a/datastore/get_notification_url.go
+++ b/datastore/get_notification_url.go
@@ -1,0 +1,59 @@
+package datastore
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	"github.com/PretendoNetwork/nex-protocols-common-go/v2/datastore/database"
+	datastore "github.com/PretendoNetwork/nex-protocols-go/v2/datastore"
+	datastore_constants "github.com/PretendoNetwork/nex-protocols-go/v2/datastore/constants"
+	datastore_types "github.com/PretendoNetwork/nex-protocols-go/v2/datastore/types"
+)
+
+func (commonProtocol *CommonProtocol) getNotificationURL(err error, packet nex.PacketInterface, callID uint32, param datastore_types.DataStoreGetNotificationURLParam) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.DataStore.Unknown, err.Error())
+	}
+
+	manager := commonProtocol.manager
+	connection := packet.Sender()
+	endpoint := connection.Endpoint()
+
+	key := fmt.Sprintf("%020d.bin", connection.PID())
+	getData, err := manager.S3.PresignNotify(key, time.Hour*24*7) // * 1 week
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.DataStore.Unknown, "Failed to sign get request")
+	}
+
+	url := getData.URL
+
+	// * Replicate the same encoding as official servers
+	var info datastore_types.DataStoreReqGetNotificationURLInfo
+	info.URL = types.String(url.Scheme + "://" + url.Host + "/")
+	info.Key = types.String(url.Path)
+	info.Query = types.String("?" + url.RawQuery)
+
+	// * This method triggers a new notification with an invalid data ID
+	errCode := database.SendNotification(manager, datastore_constants.InvalidDataID, connection.PID(), connection.PID())
+	if errCode != nil {
+		return nil, errCode
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	info.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = datastore.ProtocolID
+	rmcResponse.MethodID = datastore.MethodGetNotificationURL
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/datastore/get_notification_url.go
+++ b/datastore/get_notification_url.go
@@ -2,12 +2,13 @@ package datastore
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/PretendoNetwork/nex-go/v2"
 	"github.com/PretendoNetwork/nex-go/v2/types"
-	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
 	"github.com/PretendoNetwork/nex-protocols-common-go/v2/datastore/database"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
 	datastore "github.com/PretendoNetwork/nex-protocols-go/v2/datastore"
 	datastore_constants "github.com/PretendoNetwork/nex-protocols-go/v2/datastore/constants"
 	datastore_types "github.com/PretendoNetwork/nex-protocols-go/v2/datastore/types"
@@ -35,7 +36,7 @@ func (commonProtocol *CommonProtocol) getNotificationURL(err error, packet nex.P
 	// * Replicate the same encoding as official servers
 	var info datastore_types.DataStoreReqGetNotificationURLInfo
 	info.URL = types.String(url.Scheme + "://" + url.Host + "/")
-	info.Key = types.String(url.Path)
+	info.Key = types.String(strings.TrimPrefix(url.Path, "/"))
 	info.Query = types.String("?" + url.RawQuery)
 
 	// * This method triggers a new notification with an invalid data ID

--- a/datastore/get_notification_url.go
+++ b/datastore/get_notification_url.go
@@ -24,8 +24,8 @@ func (commonProtocol *CommonProtocol) getNotificationURL(err error, packet nex.P
 	connection := packet.Sender()
 	endpoint := connection.Endpoint()
 
-	key := fmt.Sprintf("%020d.bin", connection.PID())
-	getData, err := manager.S3.PresignNotify(key, time.Hour*24*7) // * 1 week
+	key := fmt.Sprintf("notifications/%020d.bin", connection.PID())
+	getData, err := manager.S3.PresignGet(key, time.Hour*24*7) // * 1 week
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nil, nex.NewError(nex.ResultCodes.DataStore.Unknown, "Failed to sign get request")

--- a/datastore/get_object_infos.go
+++ b/datastore/get_object_infos.go
@@ -84,7 +84,7 @@ func (commonProtocol *CommonProtocol) getObjectInfos(err error, packet nex.Packe
 			continue
 		}
 
-		key := fmt.Sprintf("%020d_%010d.bin", metaInfo.DataID, version)
+		key := fmt.Sprintf("objects/%020d_%010d.bin", metaInfo.DataID, version)
 		getData, err := manager.S3.PresignGet(key, time.Minute*15)
 		if err != nil {
 			pInfos = append(pInfos, invalidReqGetInfo)

--- a/datastore/prepare_get_object.go
+++ b/datastore/prepare_get_object.go
@@ -78,7 +78,7 @@ func (commonProtocol *CommonProtocol) prepareGetObject(err error, packet nex.Pac
 		return nil, errCode
 	}
 
-	key := fmt.Sprintf("%020d_%010d.bin", metaInfo.DataID, version)
+	key := fmt.Sprintf("objects/%020d_%010d.bin", metaInfo.DataID, version)
 	getData, err := manager.S3.PresignGet(key, time.Minute*15)
 	if err != nil {
 		common_globals.Logger.Error(err.Error())

--- a/datastore/prepare_get_object_or_meta_binary.go
+++ b/datastore/prepare_get_object_or_meta_binary.go
@@ -95,7 +95,7 @@ func (commonProtocol *CommonProtocol) prepareGetObjectOrMetaBinary(err error, pa
 		pReqGetAdditionalMeta.Version = types.UInt16(version)
 		pReqGetAdditionalMeta.MetaBinary = metaInfo.MetaBinary
 	} else {
-		key := fmt.Sprintf("%020d_%010d.bin", metaInfo.DataID, version)
+		key := fmt.Sprintf("objects/%020d_%010d.bin", metaInfo.DataID, version)
 		getData, err := manager.S3.PresignGet(key, time.Minute*15)
 		if err != nil {
 			common_globals.Logger.Error(err.Error())

--- a/datastore/prepare_get_object_v1.go
+++ b/datastore/prepare_get_object_v1.go
@@ -72,7 +72,7 @@ func (commonProtocol *CommonProtocol) prepareGetObjectV1(err error, packet nex.P
 		return nil, errCode
 	}
 
-	key := fmt.Sprintf("%020d_%010d.bin", metaInfo.DataID, version)
+	key := fmt.Sprintf("objects/%020d_%010d.bin", metaInfo.DataID, version)
 	getData, err := manager.S3.PresignGet(key, time.Minute*15)
 	if err != nil {
 		common_globals.Logger.Error(err.Error())

--- a/datastore/prepare_post_object.go
+++ b/datastore/prepare_post_object.go
@@ -91,7 +91,7 @@ func (commonProtocol *CommonProtocol) preparePostObject(err error, packet nex.Pa
 	}
 
 	// * Format "DataID_Version", where "Version" always starts at 1
-	key := fmt.Sprintf("%020d_%010d.bin", dataID, 1)
+	key := fmt.Sprintf("objects/%020d_%010d.bin", dataID, 1)
 	postData, err := manager.S3.PresignPost(key, time.Minute*15)
 	if err != nil {
 		common_globals.Logger.Error(err.Error())

--- a/datastore/prepare_post_object.go
+++ b/datastore/prepare_post_object.go
@@ -72,6 +72,24 @@ func (commonProtocol *CommonProtocol) preparePostObject(err error, packet nex.Pa
 		}
 	}
 
+	// TODO - Should this be moved inside InsertObjectByPreparePostParam?
+	notifyAccessRecipientsOnCreation := (param.Flag & types.UInt32(datastore_constants.DataFlagUseNotificationOnPost)) != 0
+	if notifyAccessRecipientsOnCreation {
+		recipientIDs, errCode := manager.GetNotificationRecipients(connection.PID(), param.Permission)
+		if errCode != nil {
+			common_globals.Logger.Errorf("Error on getting notification recipients: %s", errCode.Error())
+			return nil, errCode
+		}
+
+		for _, recipientID := range recipientIDs {
+			errCode = database.SendNotification(manager, dataID, recipientID, connection.PID())
+			if errCode != nil {
+				common_globals.Logger.Errorf("Error on sending notification: %s", errCode.Error())
+				return nil, errCode
+			}
+		}
+	}
+
 	// * Format "DataID_Version", where "Version" always starts at 1
 	key := fmt.Sprintf("%020d_%010d.bin", dataID, 1)
 	postData, err := manager.S3.PresignPost(key, time.Minute*15)

--- a/datastore/prepare_post_object_v1.go
+++ b/datastore/prepare_post_object_v1.go
@@ -90,7 +90,7 @@ func (commonProtocol *CommonProtocol) preparePostObjectV1(err error, packet nex.
 	}
 
 	// * Format "DataID_Version", where "Version" always starts at 1
-	key := fmt.Sprintf("%020d_%010d.bin", dataID, 1)
+	key := fmt.Sprintf("objects/%020d_%010d.bin", dataID, 1)
 	postData, err := manager.S3.PresignPost(key, time.Minute*15)
 	if err != nil {
 		common_globals.Logger.Error(err.Error())

--- a/datastore/prepare_post_object_v1.go
+++ b/datastore/prepare_post_object_v1.go
@@ -71,6 +71,24 @@ func (commonProtocol *CommonProtocol) preparePostObjectV1(err error, packet nex.
 		return nil, errCode
 	}
 
+	// TODO - Should this be moved inside InsertObjectByPreparePostParam?
+	notifyAccessRecipientsOnCreation := (param.Flag & types.UInt32(datastore_constants.DataFlagUseNotificationOnPost)) != 0
+	if notifyAccessRecipientsOnCreation {
+		recipientIDs, errCode := manager.GetNotificationRecipients(connection.PID(), param.Permission)
+		if errCode != nil {
+			common_globals.Logger.Errorf("Error on getting notification recipients: %s", errCode.Error())
+			return nil, errCode
+		}
+
+		for _, recipientID := range recipientIDs {
+			errCode = database.SendNotification(manager, dataID, recipientID, connection.PID())
+			if errCode != nil {
+				common_globals.Logger.Errorf("Error on sending notification: %s", errCode.Error())
+				return nil, errCode
+			}
+		}
+	}
+
 	// * Format "DataID_Version", where "Version" always starts at 1
 	key := fmt.Sprintf("%020d_%010d.bin", dataID, 1)
 	postData, err := manager.S3.PresignPost(key, time.Minute*15)

--- a/datastore/prepare_update_object.go
+++ b/datastore/prepare_update_object.go
@@ -88,7 +88,7 @@ func (commonProtocol *CommonProtocol) prepareUpdateObject(err error, packet nex.
 		for _, recipientID := range recipientIDs {
 			errCode := database.SendNotification(manager, uint64(metaInfo.DataID), recipientID, connection.PID())
 			if errCode != nil {
-				common_globals.Logger.Errorf("Error on sending notification: %s", err.Error())
+				common_globals.Logger.Errorf("Error on sending notification: %s", errCode.Error())
 				return nil, errCode
 			}
 		}

--- a/datastore/prepare_update_object.go
+++ b/datastore/prepare_update_object.go
@@ -95,7 +95,7 @@ func (commonProtocol *CommonProtocol) prepareUpdateObject(err error, packet nex.
 	}
 
 	// * Format "DataID_Version"
-	key := fmt.Sprintf("%020d_%010d.bin", param.DataID, newVersion)
+	key := fmt.Sprintf("objects/%020d_%010d.bin", param.DataID, newVersion)
 	postData, err := manager.S3.PresignPost(key, time.Minute*15)
 	if err != nil {
 		common_globals.Logger.Error(err.Error())


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

**NOTE: NEEDS TESTING!**

Notifications are used by HPP to share objects with specific access recipients and notify them about it. One such example is letters on Swapdoodle. Implement the necessary functionality and methods to support it.

On the database side, add a new table `datastore.notifications` with the following columns:
- `id`: The notification ID
- `read`: Whether the notification has been read with the `GetNewArrivedNotifications` method
- `recipient_id`: The target PID of the notification
- `data_id`: The referal data ID of the notification. Can be zero on notifications triggered with `GetNotificationURL`, so don't add an actual reference
- `sender_pid`: The PID who triggered the notification. For tracking purposes since this may not always be the owner (for example, on update notifications triggered by an external PID who has the update password)
- `creation_date`: When the notification was triggered. For tracking purposes
- `read_date`: If the notification has been read, timestamp of that event. For tracking purposes

Changes on the S3 side are also required, since we want to store the notification files on a separate key than object files. For this, add a separate `NotifyKeyBase` to specify the location for notification updates, as well as using a different presign function `PresignNotify` for these files for API compatibility with the original design.

Alongside that, we need a method for actually putting files into S3 from the server itself. For this, a new `PutObject` is added into `MinIOPresigner` to keep API compatibility. I don't exactly like how this is done, so I'm open to making more changes such as renaming the `S3Presigner` interface to expand its scope in name.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.