### PR TITLE
feat: use options struct for FindMatchmakeSessionBySearchCriteria

### DIFF
--- a/matchmake-extension/auto_matchmake_with_param_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_param_postpone.go
@@ -48,7 +48,11 @@ func (commonProtocol *CommonProtocol) autoMatchmakeWithParamPostpone(err error, 
 
 	resultRange := types.NewResultRange()
 	resultRange.Length = 1
-	resultSessions, nexError := database.FindMatchmakeSessionBySearchCriteria(commonProtocol.manager, connection, autoMatchmakeParam.LstSearchCriteria, resultRange, true, &autoMatchmakeParam.SourceMatchmakeSession)
+	resultSessions, nexError := database.FindMatchmakeSessionBySearchCriteria(commonProtocol.manager, connection, autoMatchmakeParam.LstSearchCriteria, database.FindMatchmakeSessionBySearchCriteriaOptions{
+		ResultRange: resultRange,
+		PublicSession: true,
+		SourceMatchmakeSession: &autoMatchmakeParam.SourceMatchmakeSession,
+	})
 	if nexError != nil {
 		commonProtocol.manager.Mutex.Unlock()
 		return nil, nexError

--- a/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
@@ -53,7 +53,11 @@ func (commonProtocol *CommonProtocol) autoMatchmakeWithSearchCriteriaPostpone(er
 
 	resultRange := types.NewResultRange()
 	resultRange.Length = 1
-	resultSessions, nexError := database.FindMatchmakeSessionBySearchCriteria(commonProtocol.manager, connection, lstSearchCriteria, resultRange, true, &matchmakeSession)
+	resultSessions, nexError := database.FindMatchmakeSessionBySearchCriteria(commonProtocol.manager, connection, lstSearchCriteria, database.FindMatchmakeSessionBySearchCriteriaOptions{
+		ResultRange: resultRange,
+		PublicSession: true,
+		SourceMatchmakeSession: &matchmakeSession,
+	})
 	if nexError != nil {
 		commonProtocol.manager.Mutex.Unlock()
 		return nil, nexError

--- a/matchmake-extension/browse_matchmake_session.go
+++ b/matchmake-extension/browse_matchmake_session.go
@@ -29,7 +29,11 @@ func (commonProtocol *CommonProtocol) browseMatchmakeSession(err error, packet n
 		commonProtocol.CleanupMatchmakeSessionSearchCriterias(lstSearchCriteria)
 	}
 
-	sessions, nexError := database.FindMatchmakeSessionBySearchCriteria(commonProtocol.manager, connection, searchCriterias, resultRange, false, nil)
+	sessions, nexError := database.FindMatchmakeSessionBySearchCriteria(commonProtocol.manager, connection, searchCriterias, database.FindMatchmakeSessionBySearchCriteriaOptions{
+		ResultRange: resultRange,
+		PublicSession: false,
+		SourceMatchmakeSession: nil,
+	})
 	if nexError != nil {
 		commonProtocol.manager.Mutex.RUnlock()
 		return nil, nexError

--- a/matchmake-extension/database/find_matchmake_session_by_search_criteria.go
+++ b/matchmake-extension/database/find_matchmake_session_by_search_criteria.go
@@ -15,9 +15,20 @@ import (
 	pqextended "github.com/PretendoNetwork/pq-extended"
 )
 
+// FindMatchmakeSessionBySearchCriteriaOptions contains all of the options for FindMatchmakeSessionBySearchCriteria
+type FindMatchmakeSessionBySearchCriteriaOptions struct {
+	ResultRange            types.ResultRange
+	PublicSession          bool
+	SourceMatchmakeSession *match_making_types.MatchmakeSession
+}
+
 // FindMatchmakeSessionBySearchCriteria finds matchmake sessions with the given search criterias
-func FindMatchmakeSessionBySearchCriteria(manager *common_globals.MatchmakingManager, connection *nex.PRUDPConnection, searchCriterias []match_making_types.MatchmakeSessionSearchCriteria, resultRange types.ResultRange, publicSession bool, sourceMatchmakeSession *match_making_types.MatchmakeSession) ([]match_making_types.MatchmakeSession, *nex.Error) {
+func FindMatchmakeSessionBySearchCriteria(manager *common_globals.MatchmakingManager, connection *nex.PRUDPConnection, searchCriterias []match_making_types.MatchmakeSessionSearchCriteria, options FindMatchmakeSessionBySearchCriteriaOptions) ([]match_making_types.MatchmakeSession, *nex.Error) {
 	resultMatchmakeSessions := make([]match_making_types.MatchmakeSession, 0)
+
+	resultRange := options.ResultRange
+	publicSession := options.PublicSession
+	sourceMatchmakeSession := options.SourceMatchmakeSession
 
 	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
 


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

This is a proposal coming from #65 to simplify and clarify function parameters for our internal database functions, in this case for `FindMatchmakeSessionBySearchCriteria`. I'm not fully convinced of the options struct name `FindMatchmakeSessionBySearchCriteriaOptions` as it is very long, so other ideas are welcome

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.