### PR TITLE
feat(matchmake-extension): implement password checks properly

### DIFF
--- a/matchmake-extension/auto_matchmake_with_param_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_param_postpone.go
@@ -48,7 +48,7 @@ func (commonProtocol *CommonProtocol) autoMatchmakeWithParamPostpone(err error, 
 
 	resultRange := types.NewResultRange()
 	resultRange.Length = 1
-	resultSessions, nexError := database.FindMatchmakeSessionBySearchCriteria(commonProtocol.manager, connection, autoMatchmakeParam.LstSearchCriteria, resultRange, true, &autoMatchmakeParam.SourceMatchmakeSession)
+	resultSessions, nexError := database.FindMatchmakeSessionBySearchCriteria(commonProtocol.manager, connection, autoMatchmakeParam.LstSearchCriteria, resultRange, &autoMatchmakeParam.SourceMatchmakeSession, true)
 	if nexError != nil {
 		commonProtocol.manager.Mutex.Unlock()
 		return nil, nexError
@@ -65,12 +65,6 @@ func (commonProtocol *CommonProtocol) autoMatchmakeWithParamPostpone(err error, 
 		}
 	} else {
 		resultSession = resultSessions[0]
-
-		// TODO - What should really happen here?
-		if resultSession.UserPasswordEnabled || resultSession.SystemPasswordEnabled {
-			commonProtocol.manager.Mutex.Unlock()
-			return nil, nex.NewError(nex.ResultCodes.RendezVous.PermissionDenied, "change_error")
-		}
 	}
 
 	participants, nexError := database.JoinMatchmakeSessionWithParticipants(commonProtocol.manager, resultSession, connection, autoMatchmakeParam.AdditionalParticipants, string(autoMatchmakeParam.JoinMessage), constants.JoinMatchmakeSessionBehaviorJoinMyself)

--- a/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
@@ -53,7 +53,7 @@ func (commonProtocol *CommonProtocol) autoMatchmakeWithSearchCriteriaPostpone(er
 
 	resultRange := types.NewResultRange()
 	resultRange.Length = 1
-	resultSessions, nexError := database.FindMatchmakeSessionBySearchCriteria(commonProtocol.manager, connection, lstSearchCriteria, resultRange, true, &matchmakeSession)
+	resultSessions, nexError := database.FindMatchmakeSessionBySearchCriteria(commonProtocol.manager, connection, lstSearchCriteria, resultRange, &matchmakeSession, true)
 	if nexError != nil {
 		commonProtocol.manager.Mutex.Unlock()
 		return nil, nexError
@@ -70,12 +70,6 @@ func (commonProtocol *CommonProtocol) autoMatchmakeWithSearchCriteriaPostpone(er
 		}
 	} else {
 		resultSession = resultSessions[0]
-
-		// TODO - What should really happen here?
-		if resultSession.UserPasswordEnabled || resultSession.SystemPasswordEnabled {
-			commonProtocol.manager.Mutex.Unlock()
-			return nil, nex.NewError(nex.ResultCodes.RendezVous.PermissionDenied, "change_error")
-		}
 	}
 
 	var vacantParticipants uint16 = 1

--- a/matchmake-extension/browse_matchmake_session.go
+++ b/matchmake-extension/browse_matchmake_session.go
@@ -29,7 +29,7 @@ func (commonProtocol *CommonProtocol) browseMatchmakeSession(err error, packet n
 		commonProtocol.CleanupMatchmakeSessionSearchCriterias(lstSearchCriteria)
 	}
 
-	sessions, nexError := database.FindMatchmakeSessionBySearchCriteria(commonProtocol.manager, connection, searchCriterias, resultRange, false, nil)
+	sessions, nexError := database.FindMatchmakeSessionBySearchCriteria(commonProtocol.manager, connection, searchCriterias, resultRange, nil, false)
 	if nexError != nil {
 		commonProtocol.manager.Mutex.RUnlock()
 		return nil, nexError

--- a/matchmake-extension/database/create_matchmake_session.go
+++ b/matchmake-extension/database/create_matchmake_session.go
@@ -40,6 +40,13 @@ func CreateMatchmakeSession(manager *common_globals.MatchmakingManager, connecti
 
 	matchmakeSession.StartedTime = startedTime
 	matchmakeSession.SessionKey = make([]byte, 32)
+
+	if len(matchmakeSession.UserPassword) > 0 {
+		matchmakeSession.UserPasswordEnabled = true
+	} else {
+		matchmakeSession.UserPasswordEnabled = false
+	}
+
 	matchmakeSession.SystemPasswordEnabled = false
 	rand.Read(matchmakeSession.SessionKey)
 

--- a/matchmake-extension/database/find_matchmake_session_by_search_criteria.go
+++ b/matchmake-extension/database/find_matchmake_session_by_search_criteria.go
@@ -16,7 +16,7 @@ import (
 )
 
 // FindMatchmakeSessionBySearchCriteria finds matchmake sessions with the given search criterias
-func FindMatchmakeSessionBySearchCriteria(manager *common_globals.MatchmakingManager, connection *nex.PRUDPConnection, searchCriterias []match_making_types.MatchmakeSessionSearchCriteria, resultRange types.ResultRange, publicSession bool, sourceMatchmakeSession *match_making_types.MatchmakeSession) ([]match_making_types.MatchmakeSession, *nex.Error) {
+func FindMatchmakeSessionBySearchCriteria(manager *common_globals.MatchmakingManager, connection *nex.PRUDPConnection, searchCriterias []match_making_types.MatchmakeSessionSearchCriteria, resultRange types.ResultRange, sourceMatchmakeSession *match_making_types.MatchmakeSession, isAutoMatchmake bool) ([]match_making_types.MatchmakeSession, *nex.Error) {
 	resultMatchmakeSessions := make([]match_making_types.MatchmakeSession, 0)
 
 	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
@@ -31,6 +31,15 @@ func FindMatchmakeSessionBySearchCriteria(manager *common_globals.MatchmakingMan
 	}
 
 	for _, searchCriteria := range searchCriterias {
+		// * If doing auto-matchmake, only allow sessions where the user is able to join
+		if isAutoMatchmake {
+			searchCriteria.VacantOnly = true
+			searchCriteria.ExcludeLocked = true
+			searchCriteria.ExcludeNonHostPID = true
+			searchCriteria.ExcludeUserPasswordSet = true
+			searchCriteria.ExcludeSystemPasswordSet = true
+		}
+
 		searchStatement := `SELECT
 			g.id,
 			g.owner_pid,
@@ -206,10 +215,6 @@ func FindMatchmakeSessionBySearchCriteria(manager *common_globals.MatchmakingMan
 
 				searchStatement += fmt.Sprintf(` AND ms.matchmake_system_type=%d`, value)
 			}
-		}
-
-		if publicSession {
-			searchStatement += ` AND ms.user_password="" AND ms.system_password=""`
 		}
 
 		// * Filter full sessions if necessary

--- a/matchmake-extension/join_matchmake_session.go
+++ b/matchmake-extension/join_matchmake_session.go
@@ -24,7 +24,7 @@ func (commonProtocol *CommonProtocol) joinMatchmakeSession(err error, packet nex
 	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
 	server := endpoint.Server
 
-	joinedMatchmakeSession, systemPassword, nexError := database.GetMatchmakeSessionByID(commonProtocol.manager, endpoint, uint32(gid))
+	joinedMatchmakeSession, _, nexError := database.GetMatchmakeSessionByID(commonProtocol.manager, endpoint, uint32(gid))
 	if nexError != nil {
 		common_globals.Logger.Error(nexError.Error())
 		commonProtocol.manager.Mutex.Unlock()
@@ -32,7 +32,7 @@ func (commonProtocol *CommonProtocol) joinMatchmakeSession(err error, packet nex
 	}
 
 	// TODO - Is this the correct error code?
-	if string(joinedMatchmakeSession.UserPassword) != "" || systemPassword != "" {
+	if joinedMatchmakeSession.UserPasswordEnabled || joinedMatchmakeSession.SystemPasswordEnabled {
 		commonProtocol.manager.Mutex.Unlock()
 		return nil, nex.NewError(nex.ResultCodes.RendezVous.PermissionDenied, "change_error")
 	}

--- a/matchmake-extension/join_matchmake_session_ex.go
+++ b/matchmake-extension/join_matchmake_session_ex.go
@@ -24,7 +24,7 @@ func (commonProtocol *CommonProtocol) joinMatchmakeSessionEx(err error, packet n
 	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
 	server := endpoint.Server
 
-	joinedMatchmakeSession, systemPassword, nexError := database.GetMatchmakeSessionByID(commonProtocol.manager, endpoint, uint32(gid))
+	joinedMatchmakeSession, _, nexError := database.GetMatchmakeSessionByID(commonProtocol.manager, endpoint, uint32(gid))
 	if nexError != nil {
 		common_globals.Logger.Error(nexError.Error())
 		commonProtocol.manager.Mutex.Unlock()
@@ -32,7 +32,7 @@ func (commonProtocol *CommonProtocol) joinMatchmakeSessionEx(err error, packet n
 	}
 
 	// TODO - Is this the correct error code?
-	if string(joinedMatchmakeSession.UserPassword) != "" || systemPassword != "" {
+	if joinedMatchmakeSession.UserPasswordEnabled || joinedMatchmakeSession.SystemPasswordEnabled {
 		commonProtocol.manager.Mutex.Unlock()
 		return nil, nex.NewError(nex.ResultCodes.RendezVous.PermissionDenied, "change_error")
 	}

--- a/matchmake-extension/join_matchmake_session_with_param.go
+++ b/matchmake-extension/join_matchmake_session_with_param.go
@@ -40,14 +40,14 @@ func (commonProtocol *CommonProtocol) joinMatchmakeSessionWithParam(err error, p
 		return nil, nexError
 	}
 
-	if !joinMatchmakeSessionParam.StrUserPassword.Equals(joinedMatchmakeSession.UserPassword) {
+	if bool(joinedMatchmakeSession.UserPasswordEnabled) && !joinMatchmakeSessionParam.StrUserPassword.Equals(joinedMatchmakeSession.UserPassword) {
 		commonProtocol.manager.Mutex.Unlock()
-		return nil, nex.NewError(nex.ResultCodes.RendezVous.MatchmakeSessionUserPasswordUnmatch, "change_error")
+		return nil, nex.NewError(nex.ResultCodes.RendezVous.MatchmakeSessionUserPasswordUnmatch, "Matchmake session user password does not match")
 	}
 
-	if string(joinMatchmakeSessionParam.StrSystemPassword) != systemPassword {
+	if bool(joinedMatchmakeSession.SystemPasswordEnabled) && string(joinMatchmakeSessionParam.StrSystemPassword) != systemPassword {
 		commonProtocol.manager.Mutex.Unlock()
-		return nil, nex.NewError(nex.ResultCodes.RendezVous.MatchmakeSessionSystemPasswordUnmatch, "change_error")
+		return nil, nex.NewError(nex.ResultCodes.RendezVous.MatchmakeSessionSystemPasswordUnmatch, "Matchmake session system password does not match")
 	}
 
 	// * Allow game servers to do their own permissions checks


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

It is more than likely that the UserPasswordEnabled and SystemPasswordEnabled are expected to be controlled by the server. This explains why games would set passwords with UserPasswordEnabled set to false, and also makes sense considering these bools were added on a later version compared to the passwords themselves.

Instead of relying on the password field to do these checks, toggle the UserPasswordEnabled boolean within the server to fully cover our password checks, and also allowing us to go back to checking the booleans.

Also repurpose the `publicSession` field as a `isAutoMatchmake` to filter out sessions where auto-matchmake is impossible. This also allows covering #59 too

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.