### PR TITLE
Treat GRPC token errors as expired tokens

### DIFF
--- a/globals/authentication.go
+++ b/globals/authentication.go
@@ -69,7 +69,9 @@ func ValidatePNLoginData(pid types.PID, loginData types.DataHolder, gameServerID
 		Token:         tokenBase64,
 	})
 	if err != nil {
-		return nex.NewError(nex.ResultCodes.Authentication.ValidationFailed, err.Error())
+		// * If GRPC respondes with an error, it means the token has expired or wasn't valid to begin with.
+		// * `TokenExpired` will force the console to request a new token
+		return nex.NewError(nex.ResultCodes.Authentication.TokenExpired, err.Error())
 	}
 
 	// * The account server database separates all the token types into their own


### PR DESCRIPTION
Changes:
- Treat GRPC token errors as expired tokens

This resolves the issue where consoles have to be restarted every hour (tokens expire after an hour)

Every expired token enters the flow as a GRPC error ([see here](https://github.com/PretendoNetwork/account/blob/fc1206184f25e3703af948c4a0fdcf1b15f26ce4/src/services/grpc/account/v2/exchange-nex-token-for-user-data.ts#L14-L35)).
This was handled as a `ValidationFailed` NEX error. The console just gives that error back as a popup and kicks the user out of the game.

If we handle it as a `TokenExpired`, it tells the console to get a new token and try connecting again. This resolves all issues regarding expired tokens that we've had since the opaque tokens PR.
