### PR TITLE
feat(match-making): implement GetDetailedParticipants

### DIFF
--- a/globals/matchmake_referee_globals.go
+++ b/globals/matchmake_referee_globals.go
@@ -1,0 +1,22 @@
+package common_globals
+
+import (
+	"database/sql"
+	"sync"
+
+	"github.com/PretendoNetwork/nex-go/v2"
+)
+
+type MatchmakeRefereeManager struct {
+    Database *sql.DB
+    Endpoint *nex.PRUDPEndPoint
+    Mutex    *sync.RWMutex
+}
+
+func NewMatchmakeRefereeManager(endpoint *nex.PRUDPEndPoint, db *sql.DB) *MatchmakeRefereeManager {
+	return &MatchmakeRefereeManager{
+		Endpoint: endpoint,
+		Database: db,
+		Mutex:    &sync.RWMutex{},
+	}
+}

--- a/globals/utils.go
+++ b/globals/utils.go
@@ -57,7 +57,7 @@ func CheckValidMatchmakeSession(matchmakeSession match_making_types.MatchmakeSes
 		return false
 	}
 
-	if len(matchmakeSession.Attributes) != 6 {
+	if len(matchmakeSession.Attributes) != 9 {
 		return false
 	}
 
@@ -74,8 +74,8 @@ func CheckValidMatchmakeSession(matchmakeSession match_making_types.MatchmakeSes
 		return false
 	}
 
-	// * All buffers must have a length lower than 512
-	if len(matchmakeSession.ApplicationBuffer) > 512 {
+	// * All buffers must have a length lower than 1024
+	if len(matchmakeSession.ApplicationBuffer) > 1024 {
 		return false
 	}
 

--- a/match-making/database/get_detailed_participants.go
+++ b/match-making/database/get_detailed_participants.go
@@ -1,0 +1,54 @@
+package database
+
+import (
+	"database/sql"
+
+	"github.com/PretendoNetwork/pq-extended"
+
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	matchmaking_types "github.com/PretendoNetwork/nex-protocols-go/v2/match-making/types"
+)
+
+// GetDetailedParticipants takes an array of participants associated with a gathering ID and creates info for each participant
+func GetDetailedParticipants(manager *common_globals.MatchmakingManager, gatheringID types.UInt32) (types.List[matchmaking_types.ParticipantDetails], *nex.Error) {
+	var participantList []uint64
+
+	err := manager.Database.QueryRow(`SELECT participants FROM matchmaking.gatherings WHERE id = $1`, gatheringID).Scan(pqextended.Array(&participantList))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return types.NewList[matchmaking_types.ParticipantDetails](), nex.NewError(nex.ResultCodes.RendezVous.SessionVoid, err.Error())
+		} else {
+			return types.NewList[matchmaking_types.ParticipantDetails](), nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+		}
+	}
+
+	if len(participantList) == 0 {
+		// * Empty gathering
+		return types.NewList[matchmaking_types.ParticipantDetails](), nil
+	}
+
+	var participantDetails types.List[matchmaking_types.ParticipantDetails]
+
+	for _, participant := range participantList {
+		participantInfo := matchmaking_types.NewParticipantDetails()
+		err = manager.Database.QueryRow(`SELECT owner_pid, message FROM matchmaking.messages WHERE gathering_id = $1 AND owner_pid = $2`, gatheringID, participant).Scan(&participantInfo.IDParticipant, &participantInfo.StrMessage)
+		if err != nil {
+			common_globals.Logger.Error(err.Error())
+			continue
+		}
+
+		accountDetails, err := manager.Endpoint.AccountDetailsByPID(types.NewPID(participant))
+		if err != nil {
+			return types.NewList[matchmaking_types.ParticipantDetails](), nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+		}
+
+		participantInfo.StrName = types.String(accountDetails.Username)
+		participantInfo.UIParticipants = types.UInt16(len(participantList))
+
+		participantDetails = append(participantDetails, participantInfo)
+	}
+
+	return participantDetails, nil
+}

--- a/match-making/database/get_detailed_participants.go
+++ b/match-making/database/get_detailed_participants.go
@@ -33,7 +33,7 @@ func GetDetailedParticipants(manager *common_globals.MatchmakingManager, gatheri
 
 	for _, participant := range participantList {
 		participantInfo := matchmaking_types.NewParticipantDetails()
-		err = manager.Database.QueryRow(`SELECT owner_pid, message FROM matchmaking.messages WHERE gathering_id = $1 AND owner_pid = $2`, gatheringID, participant).Scan(&participantInfo.IDParticipant, &participantInfo.StrMessage)
+		err = manager.Database.QueryRow(`SELECT pid, message FROM matchmaking.messages WHERE gathering_id = $1 AND pid = $2`, gatheringID, participant).Scan(&participantInfo.IDParticipant, &participantInfo.StrMessage)
 		if err != nil {
 			common_globals.Logger.Error(err.Error())
 			continue

--- a/match-making/database/join_gathering.go
+++ b/match-making/database/join_gathering.go
@@ -64,7 +64,12 @@ func JoinGathering(manager *common_globals.MatchmakingManager, gatheringID uint3
 		}
 	}
 
-	nexError := tracking.LogJoinGathering(manager.Database, connection.PID(), gatheringID, newParticipants, totalParticipants)
+	nexError := RecordMessage(manager, gatheringID, connection.PID(), joinMessage)
+	if nexError != nil {
+		return 0, nexError
+	}
+
+	nexError = tracking.LogJoinGathering(manager.Database, connection.PID(), gatheringID, newParticipants, totalParticipants)
 	if nexError != nil {
 		return 0, nexError
 	}

--- a/match-making/database/join_gathering_with_participants.go
+++ b/match-making/database/join_gathering_with_participants.go
@@ -62,8 +62,13 @@ func JoinGatheringWithParticipants(manager *common_globals.MatchmakingManager, g
 		return 0, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
 	}
 
+	nexError := RecordMessage(manager, gatheringID, connection.PID(), joinMessage)
+	if nexError != nil {
+		return 0, nexError
+	}
+
 	// NOTE - This will log even if no new participants are added
-	nexError := tracking.LogJoinGathering(manager.Database, connection.PID(), gatheringID, newParticipants, participants)
+	nexError = tracking.LogJoinGathering(manager.Database, connection.PID(), gatheringID, newParticipants, participants)
 	if nexError != nil {
 		return 0, nexError
 	}

--- a/match-making/database/record_message.go
+++ b/match-making/database/record_message.go
@@ -1,0 +1,16 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+func RecordMessage(manager *common_globals.MatchmakingManager, gatheringID uint32, PID types.PID, message string) *nex.Error {
+	_, err := manager.Database.Exec(`INSERT INTO matchmaking.messages (gathering_id, pid, message) VALUES ($1, $2, $3)`, gatheringID, PID, message)
+	if err != nil {
+		return nex.NewError(nex.ResultCodes.Core.SystemError, err.Error())
+	}
+
+	return nil
+}

--- a/match-making/get_detailed_participants.go
+++ b/match-making/get_detailed_participants.go
@@ -1,0 +1,38 @@
+package matchmaking
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	"github.com/PretendoNetwork/nex-protocols-common-go/v2/match-making/database"
+	match_making "github.com/PretendoNetwork/nex-protocols-go/v2/match-making"
+)
+
+func (commonProtocol *CommonProtocol) GetDetailedParticipants(err error, packet nex.PacketInterface, callID uint32, idGathering types.UInt32) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "change_error")
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+
+	participantDetails, nexError := database.GetDetailedParticipants(commonProtocol.manager, idGathering)
+	if nexError != nil {
+		common_globals.Logger.Error(nexError.Error())
+		return nil, nexError
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	participantDetails.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = match_making.ProtocolID
+	rmcResponse.MethodID = match_making.MethodGetDetailedParticipants
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/match-making/protocol.go
+++ b/match-making/protocol.go
@@ -56,6 +56,17 @@ func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.Matchma
 		return
 	}
 
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS matchmaking.messages (
+		gathering_id bigint,
+		pid numeric(20),
+		message text,
+		PRIMARY KEY (gathering_id, pid)
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
 	_, err = manager.Database.Exec(`CREATE SCHEMA IF NOT EXISTS tracking`)
 	if err != nil {
 		common_globals.Logger.Error(err.Error())

--- a/match-making/protocol.go
+++ b/match-making/protocol.go
@@ -169,6 +169,7 @@ func NewCommonProtocol(protocol match_making.Interface) *CommonProtocol {
 	}
 
 	protocol.SetHandlerUnregisterGathering(commonProtocol.unregisterGathering)
+	protocol.SetHandlerGetDetailedParticipants(commonProtocol.GetDetailedParticipants)
 	protocol.SetHandlerFindBySingleID(commonProtocol.findBySingleID)
 	protocol.SetHandlerUpdateSessionURL(commonProtocol.updateSessionURL)
 	protocol.SetHandlerUpdateSessionHostV1(commonProtocol.updateSessionHostV1)

--- a/matchmake-referee/database/end_round.go
+++ b/matchmake-referee/database/end_round.go
@@ -1,0 +1,73 @@
+package matchmake_referee_database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-referee/types"
+)
+
+func EndRound(manager *common_globals.UtilityManager, pid types.PID, roundId types.UInt64, personalRoundResults types.List[matchmake_referee_types.MatchmakeRefereePersonalRoundResult]) *nex.Error {
+
+	// * Initialize category that will be fetched for stats updating
+
+	var category types.UInt64
+
+	// TODO - Are the states supposed to have a specific value, or is it server-assigned?
+
+	err := manager.Database.QueryRow(`UPDATE matchmake_referee.rounds SET state = 1 where round_id = $1 RETURNING personal_data_category`, roundId).Scan(&category)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	for _, result := range personalRoundResults {
+		_, err := manager.Database.Exec(`
+			INSERT INTO matchmake_referee.round_results
+				(round_id, pid, personal_round_result_flag, round_win_loss,
+				rating_value_change, buffer) 
+				VALUES ($1, $2, $3, $4, $5, $6)
+			ON CONFLICT (round_id, pid) DO NOTHING /* Result was already inserted by another RMC call*/`, roundId, result.PID, result.PersonalRoundResultFlag, result.RoundWinLoss, result.RatingValueChange, result.Buffer)
+		if err != nil {
+			common_globals.Logger.Error(err.Error())
+			return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+		}
+
+		// * While it may seem beneficial to wrap the whole function to only run if it is the connection PID
+		// * Players that get disconnect/leave with EndRoundWithoutReport still have a report from other players. The above is run by everyone so those reports are fetched.
+
+		if pid == result.PID {
+			_, err := manager.Database.Exec(`
+				UPDATE matchmake_referee.stats SET rating_value = rating_value + $1 WHERE category = $2 AND owner_pid = $3`, result.RatingValueChange, category, result.PID)
+			if err != nil {
+				common_globals.Logger.Error(err.Error())
+				return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+			}
+
+			switch result.RoundWinLoss {
+			case 0:
+				_, err := manager.Database.Exec(`
+					UPDATE matchmake_referee.stats SET recent_loss = recent_loss + 1, total_loss = total_loss + 1 WHERE category = $1 AND owner_pid = $2`, category, result.PID)
+				if err != nil {
+					return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+				}
+			case 1:
+				_, err := manager.Database.Exec(`
+					UPDATE matchmake_referee.stats SET recent_win = recent_win + 1, total_win = total_win + 1 WHERE category = $1 AND owner_pid = $2`, category, result.PID)
+				if err != nil {
+					return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+				}
+			case 2:
+				_, err := manager.Database.Exec(`
+					UPDATE matchmake_referee.stats SET recent_draw = recent_draw + 1, total_draw = total_draw + 1 WHERE category = $1 AND owner_pid = $2`, category, result.PID)
+				if err != nil {
+					return nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+				}
+			default:
+				common_globals.Logger.Errorf("Unknown RoundWinLoss state: %d", result.RoundWinLoss)
+				return nex.NewError(nex.ResultCodes.Core.Unknown, "Unknown RoundWinLoss state")
+			}
+		}
+	}
+	return nil
+}

--- a/matchmake-referee/database/get_or_create_stats.go
+++ b/matchmake-referee/database/get_or_create_stats.go
@@ -1,0 +1,102 @@
+package matchmake_referee_database
+
+import (
+	"database/sql"
+
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-referee/types"
+)
+
+func GetOrCreateStats(manager *common_globals.UtilityManager, pid types.PID, category types.UInt32, initialRatingValue types.UInt32) (matchmake_referee_types.MatchmakeRefereeStats, *nex.Error) {
+	stats := matchmake_referee_types.NewMatchmakeRefereeStats()
+
+	// * We need the Unique ID of the player for the query. However, the client never sends the Unique ID inside of their request
+	// * To get around this, we check the user's Primary Unique ID based on their PID through the Utility database.
+	// * Mini version of CheckUserHasPrimaryUniqueID
+
+	// ? 08/04/2026 : Kirby Battle Royale appears to be creating a new unique ID every time it connects? I'm unsure as to why this is occurring, but this is flooding the stats table
+	// ? Try to look into what is going on, or look for a different method of fetching the Unique ID
+
+	// ? 08/05/2026 : Smash does not ever call for a unique ID, yet one is expected to be generated. This matches up with Kirby Fighters 2, where a unique ID is given despite there not being a call
+	// ? Adding a function to generate a unique ID to account for this for now
+
+	var unique_id types.UInt64
+
+	err := manager.Database.QueryRow(`SELECT unique_id FROM utility.unique_ids WHERE associated_pid = $1 AND is_primary_id = true`, pid).Scan(&unique_id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			// * User does not have a unique ID. To account for this, we will create one for them.
+
+			uniqueIDInfo, nexError := manager.GenerateNEXUniqueIDWithPassword(manager, pid, false)
+			if nexError != nil {
+				common_globals.Logger.Error(nexError.Error())
+				return stats, nexError
+			}
+			unique_id = uniqueIDInfo.NEXUniqueID
+		} else {
+			common_globals.Logger.Error(err.Error())
+			return stats, nex.NewError(nex.ResultCodes.Core.Unknown, "change_error")
+		}
+	}
+	row := manager.Database.QueryRow(`
+        SELECT unique_id, category, owner_pid,
+            recent_disconnection, recent_violation,
+            recent_mismatch, recent_win,
+            recent_loss, recent_draw,
+            total_disconnect, total_violation, 
+			total_mismatch, total_win, total_loss,
+            total_draw, rating_value
+        FROM matchmake_referee.stats WHERE unique_Id = $1 AND category = $2 AND owner_pid = $3`, unique_id, category, pid)
+
+	err = row.Scan(&stats.UniqueID, &stats.Category, &stats.PID, &stats.RecentDisconnection, &stats.RecentViolation,
+		&stats.RecentMismatch, &stats.RecentWin, &stats.RecentLoss, &stats.RecentDraw,
+		&stats.TotalDisconnect, &stats.TotalViolation, &stats.TotalMismatch, &stats.TotalWin, &stats.TotalLoss,
+		&stats.TotalDraw, &stats.RatingValue)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			//No row was found, meaning the user does not have existing stats. We need to create them.
+
+			_, err := manager.Database.Exec(`
+           INSERT INTO matchmake_referee.stats (
+               unique_id, category, owner_pid,
+               recent_disconnection, recent_violation,
+               recent_mismatch, recent_win,
+               recent_loss, recent_draw,
+               total_disconnect, total_violation,
+				total_mismatch, total_win, total_loss,
+               total_draw, rating_value
+           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+       `, unique_id, category, pid, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, initialRatingValue)
+			if err != nil {
+				common_globals.Logger.Error(err.Error())
+				return stats, nex.NewError(nex.ResultCodes.Core.Unknown, "change_error")
+			}
+
+			stats.UniqueID = unique_id
+			stats.Category = category
+			stats.PID = pid
+			stats.RecentDisconnection = 0
+			stats.RecentViolation = 0
+			stats.RecentMismatch = 0
+			stats.RecentWin = 0
+			stats.RecentLoss = 0
+			stats.RecentDraw = 0
+			stats.TotalDisconnect = 0
+			stats.TotalViolation = 0
+			stats.TotalMismatch = 0
+			stats.TotalWin = 0
+			stats.TotalLoss = 0
+			stats.TotalDraw = 0
+			stats.RatingValue = initialRatingValue
+
+			return stats, nil
+		} else {
+			common_globals.Logger.Error(err.Error())
+			return stats, nex.NewError(nex.ResultCodes.Core.Unknown, "change_error")
+		}
+	}
+
+	return stats, nil
+}

--- a/matchmake-referee/database/start_round.go
+++ b/matchmake-referee/database/start_round.go
@@ -1,0 +1,57 @@
+package matchmake_referee_database
+
+import (
+	"database/sql"
+	"slices"
+
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-referee/types"
+)
+
+func StartRound(manager *common_globals.UtilityManager, param matchmake_referee_types.MatchmakeRefereeStartRoundParam) (types.UInt64, *nex.Error) {
+	var participants types.List[types.PID]
+	var roundId types.UInt64
+	pidList := param.PIDs
+
+	// * Query for participants from the Gathering ID to insert into the new round's row. We'll perform the check for the gathering not existing here.
+
+	err := manager.Database.QueryRow(`SELECT participants FROM matchmaking.gatherings WHERE id = $1`, param.GID).Scan(&participants)
+	if err == sql.ErrNoRows {
+		common_globals.Logger.Error(err.Error())
+		return roundId, nex.NewError(nex.ResultCodes.MatchmakeReferee.NotParticipatedGathering, "Gathering does not exist")
+	} else if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return roundId, nex.NewError(nex.ResultCodes.Core.Unknown, "change_error")
+	}
+
+	// * Create the round's row in Postgres if it does not already exist. Thankfully, this only gets sent by one client so need to worry about duplicates
+
+	// TODO - Are the states supposed to have a specific value, or is it server-assigned?
+
+	err = manager.Database.QueryRow(`
+    INSERT INTO matchmake_referee.rounds (
+    gid, state, personal_data_category, participants) VALUES ($1, 0, $2, $3)
+    RETURNING round_id`, param.GID, param.PersonalDataCategory, param.PIDs).Scan(&roundId)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return roundId, nex.NewError(nex.ResultCodes.Core.Unknown, "change_error")
+	}
+
+	// * Sort both lists of PIDs in ascending order so that they are compatible
+
+	slices.Sort(participants)
+	slices.Sort(pidList)
+
+	// * Compare the lists
+
+	bool := slices.Equal(participants, pidList)
+	if bool == false {
+		return roundId, nex.NewError(nex.ResultCodes.MatchmakeReferee.NotParticipatedGathering, "change_error")
+	}
+
+	// * If we've made it to this line of code, all checks are successful.
+
+	return roundId, nil
+}

--- a/matchmake-referee/end_round.go
+++ b/matchmake-referee/end_round.go
@@ -1,0 +1,32 @@
+package matchmake_referee
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	database "github.com/PretendoNetwork/nex-protocols-common-go/v2/matchmake-referee/database"
+	matchmake_referee "github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-referee"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-referee/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+func (commonProtocol *CommonProtocol) EndRound(err error, packet nex.PacketInterface, callID uint32, param matchmake_referee_types.MatchmakeRefereeEndRoundParam) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "change_error")
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+
+	nexError := database.EndRound(commonProtocol.manager, connection.PID(), param.RoundID, param.PersonalRoundResults)
+	if nexError != nil {
+		return nil, nexError
+	}
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, nil)
+	rmcResponse.ProtocolID = matchmake_referee.ProtocolID
+	rmcResponse.MethodID = matchmake_referee.MethodEndRound
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/matchmake-referee/end_round_without_report.go
+++ b/matchmake-referee/end_round_without_report.go
@@ -1,0 +1,25 @@
+package matchmake_referee
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	matchmake_referee "github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-referee"
+)
+
+func (commonProtocol *CommonProtocol) EndRoundWithoutReport(err error, packet nex.PacketInterface, callID uint32, roundId types.UInt64) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "change_error")
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, nil)
+	rmcResponse.ProtocolID = matchmake_referee.ProtocolID
+	rmcResponse.MethodID = matchmake_referee.MethodEndRoundWithoutReport
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/matchmake-referee/get_or_create_stats.go
+++ b/matchmake-referee/get_or_create_stats.go
@@ -1,0 +1,41 @@
+package matchmake_referee
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-protocols-common-go/v2/matchmake-referee/database"
+	matchmake_referee "github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-referee"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-referee/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+func (commonProtocol *CommonProtocol) GetOrCreateStats(err error, packet nex.PacketInterface, callID uint32, param matchmake_referee_types.MatchmakeRefereeStatsInitParam) (*nex.RMCMessage, *nex.Error) {
+	// Todo: Potential limit for initialRatingValue?
+
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "change_error")
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+
+	stats, nexError := matchmake_referee_database.GetOrCreateStats(commonProtocol.manager, connection.PID(), param.Category, param.InitialRatingValue)
+	if nexError != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nexError
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	stats.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = matchmake_referee.ProtocolID
+	rmcResponse.MethodID = matchmake_referee.MethodGetOrCreateStats
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/matchmake-referee/protocol.go
+++ b/matchmake-referee/protocol.go
@@ -1,0 +1,102 @@
+package matchmake_referee
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	matchmake_referee "github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-referee"
+)
+
+type CommonProtocol struct {
+	endpoint nex.EndpointInterface
+	protocol matchmake_referee.Interface
+
+	// * MatchmakeReferee and Utility seem to potentially be tied together due to Unique IDs. I'm going to go ahead and use a UtilityManager for this as a result.
+	// * This may change in the future though.
+
+	manager *common_globals.UtilityManager
+}
+
+func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.UtilityManager) {
+	var err error
+
+	commonProtocol.manager = manager
+
+	_, err = manager.Database.Exec(`CREATE SCHEMA IF NOT EXISTS matchmake_referee`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
+	// Create the stats table. This is based on the MatchmakeRefereeStats structure, while also including the PID of the owner
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS matchmake_referee.stats (
+        unique_id numeric(20), 
+        category int,
+        owner_pid numeric(20),
+
+        recent_disconnection int,
+        recent_violation int,
+        recent_mismatch int,
+        recent_win int,
+        recent_loss int,
+        recent_draw int,
+        total_disconnect int,
+        total_violation int,
+        total_mismatch int,
+        total_win int,
+        total_loss int,
+        total_draw int,
+        rating_value bigint,
+
+        PRIMARY KEY (unique_id, category, owner_pid)
+        )`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
+	// Previously made the assumption that round_id and gid would always be the same. This is definitely not the case as I look further into it.
+	// round_id will remain as a bigserial, but gid will be shifted into being a bigint
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS matchmake_referee.rounds (
+        round_id bigserial PRIMARY KEY,
+        gid bigint,
+        state int,
+        personal_data_category int,
+        participants numeric(20)[] NOT NULL DEFAULT array[]::numeric(20)[]
+    )`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS matchmake_referee.round_results (
+		round_id bigint,
+		pid numeric(20),
+		personal_round_result_flag int,
+		round_win_loss int,
+		rating_value_change bigint,
+		buffer bytea,
+
+		PRIMARY KEY (round_id, pid)
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+}
+
+// NewCommonProtocol returns a new CommonProtocol
+func NewCommonProtocol(endpoint nex.EndpointInterface, protocol matchmake_referee.Interface) *CommonProtocol {
+
+	commonProtocol := &CommonProtocol{
+		endpoint: protocol.Endpoint(),
+		protocol: protocol,
+	}
+
+	protocol.SetHandlerStartRound(commonProtocol.StartRound)
+	protocol.SetHandlerEndRound(commonProtocol.EndRound)
+	protocol.SetHandlerEndRoundWithoutReport(commonProtocol.EndRoundWithoutReport)
+	protocol.SetHandlerGetOrCreateStats(commonProtocol.GetOrCreateStats)
+
+	return commonProtocol
+}

--- a/matchmake-referee/start_round.go
+++ b/matchmake-referee/start_round.go
@@ -1,0 +1,59 @@
+package matchmake_referee
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	database "github.com/PretendoNetwork/nex-protocols-common-go/v2/matchmake-referee/database"
+	matchmake_referee "github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-referee"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-referee/types"
+	notifications_constants "github.com/PretendoNetwork/nex-protocols-go/v2/notifications/constants"
+	notifications_types "github.com/PretendoNetwork/nex-protocols-go/v2/notifications/types"
+
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+func (commonProtocol *CommonProtocol) StartRound(err error, packet nex.PacketInterface, callID uint32, param matchmake_referee_types.MatchmakeRefereeStartRoundParam) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "change_error")
+	}
+
+	if len(param.PIDs) == 0 {
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "Client returned empty list")
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+
+	var roundId types.UInt64
+
+	roundId, nexError := database.StartRound(commonProtocol.manager, param)
+	if nexError != nil {
+		return nil, nexError
+	}
+
+	oEvent := notifications_types.NewNotificationEvent()
+	oEvent.PIDSource = connection.PID().Copy().(types.PID)
+	oEvent.Type = notifications_constants.NotificationCategoryRoundStarted.Build()
+	oEvent.Param1 = roundId
+
+	pids := make([]uint64, 0, len(param.PIDs))
+	for _, pid := range param.PIDs {
+		pids = append(pids, uint64(pid))
+	}
+
+	common_globals.SendNotificationEvent(endpoint, oEvent, pids)
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	roundId.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = matchmake_referee.ProtocolID
+	rmcResponse.MethodID = matchmake_referee.MethodStartRound
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/ticket-granting/protocol.go
+++ b/ticket-granting/protocol.go
@@ -57,6 +57,9 @@ func NewCommonProtocol(protocol ticket_granting.Interface) *CommonProtocol {
 
 	protocol.SetHandlerLogin(commonProtocol.login)
 	protocol.SetHandlerLoginEx(commonProtocol.loginEx)
+	if protocol.Endpoint().LibraryVersions().Main.GreaterOrEqual("4.0.0") {
+		protocol.SetHandlerValidateAndRequestTicketWithCustomData(commonProtocol.loginEx)
+	}
 	protocol.SetHandlerRequestTicket(commonProtocol.requestTicket)
 
 	commonProtocol.DisableInsecureLogin() // * Disable insecure login by default


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #72 as a side effect

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

This will implement GetDetailedParticipants from MatchMakingProtocol. In the process, it resolves the issue mentioned above by creating a table that strMessage can be stored in with the gathering ID and user PID as the primary key. The table can then be queried any time strMessage is needed, such as by GetDetailedParticipants.

These changes have been tested and confirmed working with Monster Hunter 3 Ultimate. I'm going to go ahead and mark this as not an approved issue as implementing the method was not technically in the scope of the issue, though it is something I wish to see merged.

I'm more than happy to create a second pull request and/or issue to implement the method to split this one if that would be preferred.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.