### PR TITLE
feat(match-making): implement GetDetailedParticipants

### DIFF
--- a/match-making/database/get_detailed_participants.go
+++ b/match-making/database/get_detailed_participants.go
@@ -1,0 +1,60 @@
+package database
+
+import (
+	"database/sql"
+
+	"github.com/PretendoNetwork/pq-extended"
+	"slices"
+
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	matchmaking_types "github.com/PretendoNetwork/nex-protocols-go/v2/match-making/types"
+)
+
+// GetDetailedParticipants takes an array of participants associated with a gathering ID and creates info for each participant
+func GetDetailedParticipants(manager *common_globals.MatchmakingManager, gatheringID types.UInt32, sourcePID types.PID) (types.List[matchmaking_types.ParticipantDetails], *nex.Error) {
+	var participantList []uint64
+
+	err := manager.Database.QueryRow(`SELECT participants FROM matchmaking.gatherings WHERE id = $1`, gatheringID).Scan(pqextended.Array(&participantList))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return types.NewList[matchmaking_types.ParticipantDetails](), nex.NewError(nex.ResultCodes.RendezVous.SessionVoid, err.Error())
+		} else {
+			return types.NewList[matchmaking_types.ParticipantDetails](), nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+		}
+	}
+
+	if len(participantList) == 0 {
+		// * Empty gathering
+		return types.NewList[matchmaking_types.ParticipantDetails](), nil
+	}
+
+	if !slices.Contains(participantList, uint64(sourcePID)) {
+		// * Is this the right error to use?
+		return types.NewList[matchmaking_types.ParticipantDetails](), nex.NewError(nex.ResultCodes.RendezVous.NotParticipatedGathering, "User attempted GetDetailedParticipants inside of a NotParticipatedGathering")
+	}
+
+	var participantDetails types.List[matchmaking_types.ParticipantDetails]
+
+	for _, participant := range participantList {
+		participantInfo := matchmaking_types.NewParticipantDetails()
+		err = manager.Database.QueryRow(`SELECT pid, message FROM matchmaking.messages WHERE gathering_id = $1 AND pid = $2`, gatheringID, participant).Scan(&participantInfo.IDParticipant, &participantInfo.StrMessage)
+		if err != nil {
+			common_globals.Logger.Error(err.Error())
+			continue
+		}
+
+		accountDetails, err := manager.Endpoint.AccountDetailsByPID(types.NewPID(participant))
+		if err != nil {
+			return types.NewList[matchmaking_types.ParticipantDetails](), nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+		}
+
+		participantInfo.StrName = types.String(accountDetails.Username)
+		participantInfo.UIParticipants = types.UInt16(len(participantList))
+
+		participantDetails = append(participantDetails, participantInfo)
+	}
+
+	return participantDetails, nil
+}

--- a/match-making/database/get_detailed_participants.go
+++ b/match-making/database/get_detailed_participants.go
@@ -12,7 +12,7 @@ import (
 	matchmaking_types "github.com/PretendoNetwork/nex-protocols-go/v2/match-making/types"
 )
 
-// GetDetailedParticipants takes an array of participants associated with a gathering ID and creates info for each participant
+// GetDetailedParticipants returns detailed information about the participants of the given gathering
 func GetDetailedParticipants(manager *common_globals.MatchmakingManager, gatheringID types.UInt32, sourcePID types.PID) (types.List[matchmaking_types.ParticipantDetails], *nex.Error) {
 	var participantList []uint64
 
@@ -37,9 +37,16 @@ func GetDetailedParticipants(manager *common_globals.MatchmakingManager, gatheri
 
 	var participantDetails types.List[matchmaking_types.ParticipantDetails]
 
-	for _, participant := range participantList {
+	for _, participant := range common_globals.RemoveDuplicates(participantList) {
 		participantInfo := matchmaking_types.NewParticipantDetails()
-		err = manager.Database.QueryRow(`SELECT pid, message FROM matchmaking.messages WHERE gathering_id = $1 AND pid = $2`, gatheringID, participant).Scan(&participantInfo.IDParticipant, &participantInfo.StrMessage)
+
+		for _, pid := range participantList {
+			if participant == pid {
+				participantInfo.UIParticipants += 1
+			}
+		}
+
+		err = manager.Database.QueryRow(`SELECT pid, message FROM matchmaking.join_messages WHERE gathering_id = $1 AND pid = $2`, gatheringID, participant).Scan(&participantInfo.IDParticipant, &participantInfo.StrMessage)
 		if err != nil {
 			common_globals.Logger.Error(err.Error())
 			continue
@@ -47,11 +54,11 @@ func GetDetailedParticipants(manager *common_globals.MatchmakingManager, gatheri
 
 		accountDetails, err := manager.Endpoint.AccountDetailsByPID(types.NewPID(participant))
 		if err != nil {
-			return types.NewList[matchmaking_types.ParticipantDetails](), nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+			common_globals.Logger.Error(err.Error())
+			continue
 		}
 
 		participantInfo.StrName = types.String(accountDetails.Username)
-		participantInfo.UIParticipants = types.UInt16(len(participantList))
 
 		participantDetails = append(participantDetails, participantInfo)
 	}

--- a/match-making/database/join_gathering.go
+++ b/match-making/database/join_gathering.go
@@ -64,7 +64,12 @@ func JoinGathering(manager *common_globals.MatchmakingManager, gatheringID uint3
 		}
 	}
 
-	nexError := tracking.LogJoinGathering(manager.Database, connection.PID(), gatheringID, newParticipants, totalParticipants)
+	nexError := RecordMessage(manager, gatheringID, connection.PID(), joinMessage)
+	if nexError != nil {
+		return 0, nexError
+	}
+
+	nexError = tracking.LogJoinGathering(manager.Database, connection.PID(), gatheringID, newParticipants, totalParticipants)
 	if nexError != nil {
 		return 0, nexError
 	}

--- a/match-making/database/join_gathering.go
+++ b/match-making/database/join_gathering.go
@@ -64,7 +64,7 @@ func JoinGathering(manager *common_globals.MatchmakingManager, gatheringID uint3
 		}
 	}
 
-	nexError := RecordMessage(manager, gatheringID, connection.PID(), joinMessage)
+	nexError := RecordJoinMessage(manager, gatheringID, connection.PID(), joinMessage)
 	if nexError != nil {
 		return 0, nexError
 	}

--- a/match-making/database/join_gathering_with_participants.go
+++ b/match-making/database/join_gathering_with_participants.go
@@ -62,8 +62,13 @@ func JoinGatheringWithParticipants(manager *common_globals.MatchmakingManager, g
 		return 0, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
 	}
 
+	nexError := RecordMessage(manager, gatheringID, connection.PID(), joinMessage)
+	if nexError != nil {
+		return 0, nexError
+	}
+
 	// NOTE - This will log even if no new participants are added
-	nexError := tracking.LogJoinGathering(manager.Database, connection.PID(), gatheringID, newParticipants, participants)
+	nexError = tracking.LogJoinGathering(manager.Database, connection.PID(), gatheringID, newParticipants, participants)
 	if nexError != nil {
 		return 0, nexError
 	}

--- a/match-making/database/join_gathering_with_participants.go
+++ b/match-making/database/join_gathering_with_participants.go
@@ -62,7 +62,7 @@ func JoinGatheringWithParticipants(manager *common_globals.MatchmakingManager, g
 		return 0, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
 	}
 
-	nexError := RecordMessage(manager, gatheringID, connection.PID(), joinMessage)
+	nexError := RecordJoinMessage(manager, gatheringID, connection.PID(), joinMessage)
 	if nexError != nil {
 		return 0, nexError
 	}

--- a/match-making/database/record_message.go
+++ b/match-making/database/record_message.go
@@ -1,0 +1,17 @@
+package database
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+)
+
+// This function records the strMessage or joinMessage from a Match-Making RMC call and stores it in a table for future queries
+func RecordMessage(manager *common_globals.MatchmakingManager, gatheringID uint32, PID types.PID, message string) *nex.Error {
+	_, err := manager.Database.Exec(`INSERT INTO matchmaking.messages (gathering_id, pid, message) VALUES ($1, $2, $3)`, gatheringID, PID, message)
+	if err != nil {
+		return nex.NewError(nex.ResultCodes.Core.SystemError, err.Error())
+	}
+
+	return nil
+}

--- a/match-making/database/record_message.go
+++ b/match-making/database/record_message.go
@@ -6,9 +6,9 @@ import (
 	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
 )
 
-// This function records the strMessage or joinMessage from a Match-Making RMC call and stores it in a table for future queries
-func RecordMessage(manager *common_globals.MatchmakingManager, gatheringID uint32, PID types.PID, message string) *nex.Error {
-	_, err := manager.Database.Exec(`INSERT INTO matchmaking.messages (gathering_id, pid, message) VALUES ($1, $2, $3)`, gatheringID, PID, message)
+// RecordJoinMessage records the join message from a participant into a gathering
+func RecordJoinMessage(manager *common_globals.MatchmakingManager, gatheringID uint32, PID types.PID, message string) *nex.Error {
+	_, err := manager.Database.Exec(`INSERT INTO matchmaking.join_messages (gathering_id, pid, message) VALUES ($1, $2, $3) ON CONFLICT (gathering_id, pid) DO UPDATE SET message = $3`, gatheringID, PID, message)
 	if err != nil {
 		return nex.NewError(nex.ResultCodes.Core.SystemError, err.Error())
 	}

--- a/match-making/get_detailed_participants.go
+++ b/match-making/get_detailed_participants.go
@@ -1,0 +1,38 @@
+package matchmaking
+
+import (
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	common_globals "github.com/PretendoNetwork/nex-protocols-common-go/v2/globals"
+	"github.com/PretendoNetwork/nex-protocols-common-go/v2/match-making/database"
+	match_making "github.com/PretendoNetwork/nex-protocols-go/v2/match-making"
+)
+
+func (commonProtocol *CommonProtocol) GetDetailedParticipants(err error, packet nex.PacketInterface, callID uint32, idGathering types.UInt32) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "change_error")
+	}
+
+	connection := packet.Sender().(*nex.PRUDPConnection)
+	endpoint := connection.Endpoint().(*nex.PRUDPEndPoint)
+
+	participantDetails, nexError := database.GetDetailedParticipants(commonProtocol.manager, idGathering, packet.Sender().PID())
+	if nexError != nil {
+		common_globals.Logger.Error(nexError.Error())
+		return nil, nexError
+	}
+
+	rmcResponseStream := nex.NewByteStreamOut(endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	participantDetails.WriteTo(rmcResponseStream)
+
+	rmcResponseBody := rmcResponseStream.Bytes()
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, rmcResponseBody)
+	rmcResponse.ProtocolID = match_making.ProtocolID
+	rmcResponse.MethodID = match_making.MethodGetDetailedParticipants
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/match-making/get_detailed_participants.go
+++ b/match-making/get_detailed_participants.go
@@ -8,7 +8,7 @@ import (
 	match_making "github.com/PretendoNetwork/nex-protocols-go/v2/match-making"
 )
 
-func (commonProtocol *CommonProtocol) GetDetailedParticipants(err error, packet nex.PacketInterface, callID uint32, idGathering types.UInt32) (*nex.RMCMessage, *nex.Error) {
+func (commonProtocol *CommonProtocol) getDetailedParticipants(err error, packet nex.PacketInterface, callID uint32, idGathering types.UInt32) (*nex.RMCMessage, *nex.Error) {
 	if err != nil {
 		common_globals.Logger.Error(err.Error())
 		return nil, nex.NewError(nex.ResultCodes.Core.InvalidArgument, "change_error")

--- a/match-making/protocol.go
+++ b/match-making/protocol.go
@@ -56,6 +56,17 @@ func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.Matchma
 		return
 	}
 
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS matchmaking.messages (
+		gathering_id bigint,
+		pid numeric(20),
+		message text,
+		PRIMARY KEY (gathering_id, pid)
+	)`)
+	if err != nil {
+		common_globals.Logger.Error(err.Error())
+		return
+	}
+
 	_, err = manager.Database.Exec(`CREATE SCHEMA IF NOT EXISTS tracking`)
 	if err != nil {
 		common_globals.Logger.Error(err.Error())

--- a/match-making/protocol.go
+++ b/match-making/protocol.go
@@ -169,6 +169,7 @@ func NewCommonProtocol(protocol match_making.Interface) *CommonProtocol {
 	}
 
 	protocol.SetHandlerUnregisterGathering(commonProtocol.unregisterGathering)
+	protocol.SetHandlerGetDetailedParticipants(commonProtocol.GetDetailedParticipants)
 	protocol.SetHandlerFindBySingleID(commonProtocol.findBySingleID)
 	protocol.SetHandlerUpdateSessionURL(commonProtocol.updateSessionURL)
 	protocol.SetHandlerUpdateSessionHostV1(commonProtocol.updateSessionHostV1)

--- a/match-making/protocol.go
+++ b/match-making/protocol.go
@@ -56,7 +56,7 @@ func (commonProtocol *CommonProtocol) SetManager(manager *common_globals.Matchma
 		return
 	}
 
-	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS matchmaking.messages (
+	_, err = manager.Database.Exec(`CREATE TABLE IF NOT EXISTS matchmaking.join_messages (
 		gathering_id bigint,
 		pid numeric(20),
 		message text,
@@ -169,7 +169,7 @@ func NewCommonProtocol(protocol match_making.Interface) *CommonProtocol {
 	}
 
 	protocol.SetHandlerUnregisterGathering(commonProtocol.unregisterGathering)
-	protocol.SetHandlerGetDetailedParticipants(commonProtocol.GetDetailedParticipants)
+	protocol.SetHandlerGetDetailedParticipants(commonProtocol.getDetailedParticipants)
 	protocol.SetHandlerFindBySingleID(commonProtocol.findBySingleID)
 	protocol.SetHandlerUpdateSessionURL(commonProtocol.updateSessionURL)
 	protocol.SetHandlerUpdateSessionHostV1(commonProtocol.updateSessionHostV1)


### PR DESCRIPTION
Let's try this again, preferably without file leakage.

Resolves #72 as a side effect.

### Changes:

This will implement GetDetailedParticipants from MatchMakingProtocol. In the process, it resolves the issue mentioned above by creating a table that strMessage can be stored in with the gathering ID and user PID as the primary key. The table can then be queried any time strMessage is needed, such as by GetDetailedParticipants. 

Database function RecordMessage has been inserted in Database functions JoinGathering and JoinGatheringWithParticipants to account for this. All other matchmaking functions call one of the variants while it is joining a MatchmakeSession, PersistentGathering, whatever. This makes those two functions the most optimal place to execute the functions as it will all lead to JoinGathering eventually.

These changes have been tested and confirmed working with JoinMatchmakeSessionEx and one of the AutoMatchmake methods. These were tested with Monster Hunter 3 Ultimate and Kirby Battle Royale respectively, and both tests were successful. I am going to mark this as not an approved issue due to GetDetailedParticipants technically being outside the scope of the original issue (though it was a requirement for this method to be implemented regardless).

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.